### PR TITLE
add new Decoder constructor from toml vec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -641,6 +641,15 @@ impl Decoder {
         }
     }
 
+    pub fn new_from_table(instruction_sets: Vec<Table>) -> Self {
+        Decoder {
+            instruction_sets: instruction_sets
+                .iter()
+                .map(|x| InstructionSet::new(x))
+                .collect(),
+        }
+    }
+
     pub fn decode_from_string(
         &self,
         instruction: &str,


### PR DESCRIPTION
This adds a new Decoder constructor that allows reusing already parsed toml files.