### PR TITLE
Add license information to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "instruction-decoder"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 [dependencies]
 toml = "0.8.12"


### PR DESCRIPTION
Noted while running `cargo license` for Surfer that this was not included.