### PR TITLE
Allow dot symbols in insn mnemonics by quoting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -842,7 +842,7 @@ impl Instruction {
         .unwrap()
         .clone();
 
-        let formatted_name = self.name.replace('_', ".");
+        let formatted_name = self.name.to_owned();
         fmt = fmt.replace("$name$", &formatted_name);
         while fmt.contains('%') {
             let begin = fmt.find('%').unwrap() + 1;

--- a/toml/RV32A.toml
+++ b/toml/RV32A.toml
@@ -214,46 +214,46 @@ default = "$name$%aqrl% %rd_Register_int%, %rs2_Register_int%, (%rs1_Register_in
 [format_2-0.repr]
 default = "$name$%aqrl% %rd_Register_int%, (%rs1_Register_int%)"
 
-[format_1-0.instructions.amoadd_w]
+[format_1-0.instructions."amoadd.w"]
 mask = 0xf800707f
 match = 0x202f
 
-[format_1-0.instructions.amoand_w]
+[format_1-0.instructions."amoand.w"]
 mask = 0xf800707f
 match = 0x6000202f
 
-[format_1-0.instructions.amomax_w]
+[format_1-0.instructions."amomax.w"]
 mask = 0xf800707f
 match = 0xa000202f
 
-[format_1-0.instructions.amomaxu_w]
+[format_1-0.instructions."amomaxu.w"]
 mask = 0xf800707f
 match = 0xe000202f
 
-[format_1-0.instructions.amomin_w]
+[format_1-0.instructions."amomin.w"]
 mask = 0xf800707f
 match = 0x8000202f
 
-[format_1-0.instructions.amominu_w]
+[format_1-0.instructions."amominu.w"]
 mask = 0xf800707f
 match = 0xc000202f
 
-[format_1-0.instructions.amoor_w]
+[format_1-0.instructions."amoor.w"]
 mask = 0xf800707f
 match = 0x4000202f
 
-[format_1-0.instructions.amoswap_w]
+[format_1-0.instructions."amoswap.w"]
 mask = 0xf800707f
 match = 0x800202f
 
-[format_1-0.instructions.amoxor_w]
+[format_1-0.instructions."amoxor.w"]
 mask = 0xf800707f
 match = 0x2000202f
 
-[format_1-0.instructions.sc_w]
+[format_1-0.instructions."sc.w"]
 mask = 0xf800707f
 match = 0x1800202f
 
-[format_2-0.instructions.lr_w]
+[format_2-0.instructions."lr.w"]
 mask = 0xf9f0707f
 match = 0x1000202f

--- a/toml/RV32C-lower.toml
+++ b/toml/RV32C-lower.toml
@@ -944,11 +944,11 @@ default = "$name$"
 
 [format-18-0.repr]
 default = "$name$ %rd_rs1_n0_Register_int%, %imm%"
-c_slli64 = "$name$ %rd_rs1_n0_Register_int%"
+"c.slli64" = "$name$ %rd_rs1_n0_Register_int%"
 
 [format-19-0.repr]
 default = "$name$ %rd_rs1_p_Register_int_c%, %imm%"
-c_srli64 = "$name$ %rd_rs1_p_Register_int_c%"
+"c.srli64" = "$name$ %rd_rs1_p_Register_int_c%"
 
 [format-20-0.repr]
 default = "$name$ %rs2_p_Register_int_c%, %himm%(%rs1_p_Register_int_c%)"
@@ -956,129 +956,129 @@ default = "$name$ %rs2_p_Register_int_c%, %himm%(%rs1_p_Register_int_c%)"
 [format-21-0.repr]
 default = "$name$ %c_rs2_Register_int%, %himm%(sp)"
 
-[format-01-0.instructions.c_add]
+[format-01-0.instructions."c.add"]
 mask = 0xf003
 match = 0x9002
 
-[format-02-0.instructions.c_addi]
+[format-02-0.instructions."c.addi"]
 mask = 0xe003
 match = 0x1
 
-[format-23-0.instructions.c_addi16sp]
+[format-23-0.instructions."c.addi16sp"]
 mask = 0xef83
 match = 0x6101
 
-[format-24-0.instructions.c_addi4spn]
+[format-24-0.instructions."c.addi4spn"]
 mask = 0xe003
 match = 0x0
 unsigned = true
 
-[format-05-0.instructions.c_and]
+[format-05-0.instructions."c.and"]
 mask = 0xfc63
 match = 0x8c61
 
-[format-05-0.instructions.c_or]
+[format-05-0.instructions."c.or"]
 mask = 0xfc63
 match = 0x8c41
 
-[format-05-0.instructions.c_sub]
+[format-05-0.instructions."c.sub"]
 mask = 0xfc63
 match = 0x8c01
 
-[format-05-0.instructions.c_xor]
+[format-05-0.instructions."c.xor"]
 mask = 0xfc63
 match = 0x8c21
 
-[format-06-0.instructions.c_andi]
+[format-06-0.instructions."c.andi"]
 mask = 0xec03
 match = 0x8801
 
-[format-07-0.instructions.c_beqz]
+[format-07-0.instructions."c.beqz"]
 mask = 0xe003
 match = 0xc001
 
-[format-07-0.instructions.c_bnez]
+[format-07-0.instructions."c.bnez"]
 mask = 0xe003
 match = 0xe001
 
-[format-28-0.instructions.c_ebreak]
+[format-28-0.instructions."c.ebreak"]
 mask = 0xffff
 match = 0x9002
 
-[format-09-0.instructions.c_j]
+[format-09-0.instructions."c.j"]
 mask = 0xe003
 match = 0xa001
 
-[format-09-0.instructions.c_jal]
+[format-09-0.instructions."c.jal"]
 mask = 0xe003
 match = 0x2001
 
-[format-10-0.instructions.c_jalr]
+[format-10-0.instructions."c.jalr"]
 mask = 0xf07f
 match = 0x9002
 
-[format-31-0.instructions.c_jr]
+[format-31-0.instructions."c.jr"]
 mask = 0xf07f
 match = 0x8002
 
-[format-12-0.instructions.c_li]
+[format-12-0.instructions."c.li"]
 mask = 0xe003
 match = 0x4001
 
-[format-13-0.instructions.c_lui]
+[format-13-0.instructions."c.lui"]
 mask = 0xe003
 match = 0x6001
 unsigned = true
 
-[format-14-0.instructions.c_lw]
+[format-14-0.instructions."c.lw"]
 mask = 0xe003
 match = 0x4000
 unsigned = true
 
-[format-15-0.instructions.c_lwsp]
+[format-15-0.instructions."c.lwsp"]
 mask = 0xe003
 match = 0x4002
 unsigned = true
 
-[format-16-0.instructions.c_mv]
+[format-16-0.instructions."c.mv"]
 mask = 0xf003
 match = 0x8002
 
-[format-17-0.instructions.c_nop]
+[format-17-0.instructions."c.nop"]
 mask = 0xef83
 match = 0x1
 
-[format-18-0.instructions.c_slli]
+[format-18-0.instructions."c.slli"]
 mask = 0xf003
 match = 0x2
 unsigned = true
 
-[format-18-0.instructions.c_slli64]
+[format-18-0.instructions."c.slli64"]
 mask = 0xf07f
 match = 0x2
 unsigned = true
 
-[format-19-0.instructions.c_srai]
+[format-19-0.instructions."c.srai"]
 mask = 0xfc03
 match = 0x8401
 unsigned = true
 
-[format-19-0.instructions.c_srli]
+[format-19-0.instructions."c.srli"]
 mask = 0xfc03
 match = 0x8001
 unsigned = true
 
-[format-19-0.instructions.c_srli64]
+[format-19-0.instructions."c.srli64"]
 mask = 0xfc7f
 match = 0x8001
 unsigned = true
 
-[format-20-0.instructions.c_sw]
+[format-20-0.instructions."c.sw"]
 mask = 0xe003
 match = 0xc000
 unsigned = true
 
-[format-21-0.instructions.c_swsp]
+[format-21-0.instructions."c.swsp"]
 mask = 0xe003
 match = 0xc002
 unsigned = true

--- a/toml/RV32C.toml
+++ b/toml/RV32C.toml
@@ -944,11 +944,11 @@ default = "$name$"
 
 [format-18-0.repr]
 default = "$name$ %rd_rs1_n0_Register_int%, %imm%"
-c_slli64 = "$name$ %rd_rs1_n0_Register_int%"
+"c.slli64" = "$name$ %rd_rs1_n0_Register_int%"
 
 [format-19-0.repr]
 default = "$name$ %rd_rs1_p_Register_int_c%, %imm%"
-c_srli64 = "$name$ %rd_rs1_p_Register_int_c%"
+"c.srli64" = "$name$ %rd_rs1_p_Register_int_c%"
 
 [format-20-0.repr]
 default = "$name$ %rs2_p_Register_int_c%, %himm%(%rs1_p_Register_int_c%)"
@@ -956,129 +956,129 @@ default = "$name$ %rs2_p_Register_int_c%, %himm%(%rs1_p_Register_int_c%)"
 [format-21-0.repr]
 default = "$name$ %c_rs2_Register_int%, %himm%(sp)"
 
-[format-01-0.instructions.c_add]
+[format-01-0.instructions."c.add"]
 mask = 0xf003
 match = 0x9002
 
-[format-02-0.instructions.c_addi]
+[format-02-0.instructions."c.addi"]
 mask = 0xe003
 match = 0x1
 
-[format-23-0.instructions.c_addi16sp]
+[format-23-0.instructions."c.addi16sp"]
 mask = 0xef83
 match = 0x6101
 
-[format-24-0.instructions.c_addi4spn]
+[format-24-0.instructions."c.addi4spn"]
 mask = 0xe003
 match = 0x0
 unsigned = true
 
-[format-05-0.instructions.c_and]
+[format-05-0.instructions."c.and"]
 mask = 0xfc63
 match = 0x8c61
 
-[format-05-0.instructions.c_or]
+[format-05-0.instructions."c.or"]
 mask = 0xfc63
 match = 0x8c41
 
-[format-05-0.instructions.c_sub]
+[format-05-0.instructions."c.sub"]
 mask = 0xfc63
 match = 0x8c01
 
-[format-05-0.instructions.c_xor]
+[format-05-0.instructions."c.xor"]
 mask = 0xfc63
 match = 0x8c21
 
-[format-06-0.instructions.c_andi]
+[format-06-0.instructions."c.andi"]
 mask = 0xec03
 match = 0x8801
 
-[format-07-0.instructions.c_beqz]
+[format-07-0.instructions."c.beqz"]
 mask = 0xe003
 match = 0xc001
 
-[format-07-0.instructions.c_bnez]
+[format-07-0.instructions."c.bnez"]
 mask = 0xe003
 match = 0xe001
 
-[format-28-0.instructions.c_ebreak]
+[format-28-0.instructions."c.ebreak"]
 mask = 0xffff
 match = 0x9002
 
-[format-09-0.instructions.c_j]
+[format-09-0.instructions."c.j"]
 mask = 0xe003
 match = 0xa001
 
-[format-09-0.instructions.c_jal]
+[format-09-0.instructions."c.jal"]
 mask = 0xe003
 match = 0x2001
 
-[format-10-0.instructions.c_jalr]
+[format-10-0.instructions."c.jalr"]
 mask = 0xf07f
 match = 0x9002
 
-[format-31-0.instructions.c_jr]
+[format-31-0.instructions."c.jr"]
 mask = 0xf07f
 match = 0x8002
 
-[format-12-0.instructions.c_li]
+[format-12-0.instructions."c.li"]
 mask = 0xe003
 match = 0x4001
 
-[format-13-0.instructions.c_lui]
+[format-13-0.instructions."c.lui"]
 mask = 0xe003
 match = 0x6001
 unsigned = true
 
-[format-14-0.instructions.c_lw]
+[format-14-0.instructions."c.lw"]
 mask = 0xe003
 match = 0x4000
 unsigned = true
 
-[format-15-0.instructions.c_lwsp]
+[format-15-0.instructions."c.lwsp"]
 mask = 0xe003
 match = 0x4002
 unsigned = true
 
-[format-16-0.instructions.c_mv]
+[format-16-0.instructions."c.mv"]
 mask = 0xf003
 match = 0x8002
 
-[format-17-0.instructions.c_nop]
+[format-17-0.instructions."c.nop"]
 mask = 0xef83
 match = 0x1
 
-[format-18-0.instructions.c_slli]
+[format-18-0.instructions."c.slli"]
 mask = 0xf003
 match = 0x2
 unsigned = true
 
-[format-18-0.instructions.c_slli64]
+[format-18-0.instructions."c.slli64"]
 mask = 0xf07f
 match = 0x2
 unsigned = true
 
-[format-19-0.instructions.c_srai]
+[format-19-0.instructions."c.srai"]
 mask = 0xfc03
 match = 0x8401
 unsigned = true
 
-[format-19-0.instructions.c_srli]
+[format-19-0.instructions."c.srli"]
 mask = 0xfc03
 match = 0x8001
 unsigned = true
 
-[format-19-0.instructions.c_srli64]
+[format-19-0.instructions."c.srli64"]
 mask = 0xfc7f
 match = 0x8001
 unsigned = true
 
-[format-20-0.instructions.c_sw]
+[format-20-0.instructions."c.sw"]
 mask = 0xe003
 match = 0xc000
 unsigned = true
 
-[format-21-0.instructions.c_swsp]
+[format-21-0.instructions."c.swsp"]
 mask = 0xe003
 match = 0xc002
 unsigned = true

--- a/toml/RV32F.toml
+++ b/toml/RV32F.toml
@@ -537,83 +537,83 @@ default = "$name$ %rd_Register_float%, %rs1_Register_float%, %rs2_Register_float
 [format_7-1.repr]
 default = "$name$ %rs2_Register_float%, %imm%(%rs1_Register_int%)"
 
-[format_1-7.instructions.fadd_s]
+[format_1-7.instructions."fadd.s"]
 mask = 0xfe00007f
 match = 0x53
 
-[format_1-7.instructions.fdiv_s]
+[format_1-7.instructions."fdiv.s"]
 mask = 0xfe00007f
 match = 0x18000053
 
-[format_1-7.instructions.fmul_s]
+[format_1-7.instructions."fmul.s"]
 mask = 0xfe00007f
 match = 0x10000053
 
-[format_1-7.instructions.fsub_s]
+[format_1-7.instructions."fsub.s"]
 mask = 0xfe00007f
 match = 0x8000053
 
-[format_2-1.instructions.fclass_s]
+[format_2-1.instructions."fclass.s"]
 mask = 0xfff0707f
 match = 0xe0001053
 
-[format_2-1.instructions.fmv_x_w]
+[format_2-1.instructions."fmv.x.w"]
 mask = 0xfff0707f
 match = 0xe0000053
 
-[format_2-2.instructions.fmv_w_x]
+[format_2-2.instructions."fmv.w.x"]
 mask = 0xfff0707f
 match = 0xf0000053
 
-[format_3-1.instructions.fcvt_w_s]
+[format_3-1.instructions."fcvt.w.s"]
 mask = 0xfff0007f
 match = 0xc0000053
 
-[format_3-1.instructions.fcvt_wu_s]
+[format_3-1.instructions."fcvt.wu.s"]
 mask = 0xfff0007f
 match = 0xc0100053
 
-[format_3-2.instructions.fcvt_s_w]
+[format_3-2.instructions."fcvt.s.w"]
 mask = 0xfff0007f
 match = 0xd0000053
 
-[format_3-2.instructions.fcvt_s_wu]
+[format_3-2.instructions."fcvt.s.wu"]
 mask = 0xfff0007f
 match = 0xd0100053
 
-[format_3-3.instructions.fsqrt_s]
+[format_3-3.instructions."fsqrt.s"]
 mask = 0xfff0007f
 match = 0x58000053
 
-[format_4-3.instructions.feq_s]
+[format_4-3.instructions."feq.s"]
 mask = 0xfe00707f
 match = 0xa0002053
 
-[format_4-3.instructions.fle_s]
+[format_4-3.instructions."fle.s"]
 mask = 0xfe00707f
 match = 0xa0000053
 
-[format_4-3.instructions.flt_s]
+[format_4-3.instructions."flt.s"]
 mask = 0xfe00707f
 match = 0xa0001053
 
-[format_4-7.instructions.fmax_s]
+[format_4-7.instructions."fmax.s"]
 mask = 0xfe00707f
 match = 0x28001053
 
-[format_4-7.instructions.fmin_s]
+[format_4-7.instructions."fmin.s"]
 mask = 0xfe00707f
 match = 0x28000053
 
-[format_4-7.instructions.fsgnj_s]
+[format_4-7.instructions."fsgnj.s"]
 mask = 0xfe00707f
 match = 0x20000053
 
-[format_4-7.instructions.fsgnjn_s]
+[format_4-7.instructions."fsgnjn.s"]
 mask = 0xfe00707f
 match = 0x20001053
 
-[format_4-7.instructions.fsgnjx_s]
+[format_4-7.instructions."fsgnjx.s"]
 mask = 0xfe00707f
 match = 0x20002053
 
@@ -621,19 +621,19 @@ match = 0x20002053
 mask = 0x707f
 match = 0x2007
 
-[format_6-15.instructions.fmadd_s]
+[format_6-15.instructions."fmadd.s"]
 mask = 0x600007f
 match = 0x43
 
-[format_6-15.instructions.fmsub_s]
+[format_6-15.instructions."fmsub.s"]
 mask = 0x600007f
 match = 0x47
 
-[format_6-15.instructions.fnmadd_s]
+[format_6-15.instructions."fnmadd.s"]
 mask = 0x600007f
 match = 0x4f
 
-[format_6-15.instructions.fnmsub_s]
+[format_6-15.instructions."fnmsub.s"]
 mask = 0x600007f
 match = 0x4b
 

--- a/toml/RV32_Zacas.toml
+++ b/toml/RV32_Zacas.toml
@@ -173,10 +173,10 @@ Mapping_ordering = ["", ".rl", ".aq", ".aqrl"]
 [format-1-0.repr]
 default = "$name$%aqrl% %rd_Register_int%, %rs2_Register_int%, (%rs1_Register_int%)"
 
-[format-1-0.instructions.amocas_d]
+[format-1-0.instructions."amocas.d"]
 mask = 0xf800707f
 match = 0x2800302f
 
-[format-1-0.instructions.amocas_w]
+[format-1-0.instructions."amocas.w"]
 mask = 0xf800707f
 match = 0x2800202f

--- a/toml/RV32_Zbb.toml
+++ b/toml/RV32_Zbb.toml
@@ -283,7 +283,7 @@ match = 0x60201013
 mask = 0xfff0707f
 match = 0x60101013
 
-[format_2-0.instructions.orc_b]
+[format_2-0.instructions."orc.b"]
 mask = 0xfff0707f
 match = 0x28705013
 
@@ -291,15 +291,15 @@ match = 0x28705013
 mask = 0xfff0707f
 match = 0x69805013
 
-[format_2-0.instructions.sext_b]
+[format_2-0.instructions."sext.b"]
 mask = 0xfff0707f
 match = 0x60401013
 
-[format_2-0.instructions.sext_h]
+[format_2-0.instructions."sext.h"]
 mask = 0xfff0707f
 match = 0x60501013
 
-[format_2-0.instructions.zext_h]
+[format_2-0.instructions."zext.h"]
 mask = 0xfff0707f
 match = 0x8004033
 

--- a/toml/RV32_Zcb-lower.toml
+++ b/toml/RV32_Zcb-lower.toml
@@ -273,51 +273,51 @@ default = "$name$ %rs2_p_Register_int_c%, %himm%(%rs1_p_Register_int_c%)"
 [format-6-0.repr]
 default = "$name$ %rs2_p_Register_int_c%, %himm%(%rs1_p_Register_int_c%)"
 
-[format-1-0.instructions.c_lbu]
+[format-1-0.instructions."c.lbu"]
 mask = 0xfc03
 match = 0x8000
 unsigned = true
 
-[format-2-0.instructions.c_lh]
+[format-2-0.instructions."c.lh"]
 mask = 0xfc43
 match = 0x8440
 unsigned = true
 
-[format-2-0.instructions.c_lhu]
+[format-2-0.instructions."c.lhu"]
 mask = 0xfc43
 match = 0x8400
 unsigned = true
 
-[format-3-0.instructions.c_mul]
+[format-3-0.instructions."c.mul"]
 mask = 0xfc63
 match = 0x9c41
 
-[format-4-0.instructions.c_not]
+[format-4-0.instructions."c.not"]
 mask = 0xfc7f
 match = 0x9c75
 
-[format-4-0.instructions.c_sext_b]
+[format-4-0.instructions."c.sext.b"]
 mask = 0xfc7f
 match = 0x9c65
 
-[format-4-0.instructions.c_sext_h]
+[format-4-0.instructions."c.sext.h"]
 mask = 0xfc7f
 match = 0x9c6d
 
-[format-4-0.instructions.c_zext_b]
+[format-4-0.instructions."c.zext.b"]
 mask = 0xfc7f
 match = 0x9c61
 
-[format-4-0.instructions.c_zext_h]
+[format-4-0.instructions."c.zext.h"]
 mask = 0xfc7f
 match = 0x9c69
 
-[format-5-0.instructions.c_sb]
+[format-5-0.instructions."c.sb"]
 mask = 0xfc03
 match = 0x8800
 unsigned = true
 
-[format-6-0.instructions.c_sh]
+[format-6-0.instructions."c.sh"]
 mask = 0xfc43
 match = 0x8c00
 unsigned = true

--- a/toml/RV32_Zcb.toml
+++ b/toml/RV32_Zcb.toml
@@ -273,51 +273,51 @@ default = "$name$ %rs2_p_Register_int_c%, %himm%(%rs1_p_Register_int_c%)"
 [format-6-0.repr]
 default = "$name$ %rs2_p_Register_int_c%, %himm%(%rs1_p_Register_int_c%)"
 
-[format-1-0.instructions.c_lbu]
+[format-1-0.instructions."c.lbu"]
 mask = 0xfc03
 match = 0x8000
 unsigned = true
 
-[format-2-0.instructions.c_lh]
+[format-2-0.instructions."c.lh"]
 mask = 0xfc43
 match = 0x8440
 unsigned = true
 
-[format-2-0.instructions.c_lhu]
+[format-2-0.instructions."c.lhu"]
 mask = 0xfc43
 match = 0x8400
 unsigned = true
 
-[format-3-0.instructions.c_mul]
+[format-3-0.instructions."c.mul"]
 mask = 0xfc63
 match = 0x9c41
 
-[format-4-0.instructions.c_not]
+[format-4-0.instructions."c.not"]
 mask = 0xfc7f
 match = 0x9c75
 
-[format-4-0.instructions.c_sext_b]
+[format-4-0.instructions."c.sext.b"]
 mask = 0xfc7f
 match = 0x9c65
 
-[format-4-0.instructions.c_sext_h]
+[format-4-0.instructions."c.sext.h"]
 mask = 0xfc7f
 match = 0x9c6d
 
-[format-4-0.instructions.c_zext_b]
+[format-4-0.instructions."c.zext.b"]
 mask = 0xfc7f
 match = 0x9c61
 
-[format-4-0.instructions.c_zext_h]
+[format-4-0.instructions."c.zext.h"]
 mask = 0xfc7f
 match = 0x9c69
 
-[format-5-0.instructions.c_sb]
+[format-5-0.instructions."c.sb"]
 mask = 0xfc03
 match = 0x8800
 unsigned = true
 
-[format-6-0.instructions.c_sh]
+[format-6-0.instructions."c.sh"]
 mask = 0xfc43
 match = 0x8c00
 unsigned = true

--- a/toml/RV32_Zcf-lower.toml
+++ b/toml/RV32_Zcf-lower.toml
@@ -297,22 +297,22 @@ default = "$name$ %rs2_p_Register_float_c%, %himm%(%rs1_p_Register_int_c%)"
 [format-4-0.repr]
 default = "$name$ %c_rs2_Register_float%, %himm%(sp)"
 
-[format-1-0.instructions.c_flw]
+[format-1-0.instructions."c.flw"]
 mask = 0xe003
 match = 0x6000
 unsigned = true
 
-[format-2-0.instructions.c_flwsp]
+[format-2-0.instructions."c.flwsp"]
 mask = 0xe003
 match = 0x6002
 unsigned = true
 
-[format-3-0.instructions.c_fsw]
+[format-3-0.instructions."c.fsw"]
 mask = 0xe003
 match = 0xe000
 unsigned = true
 
-[format-4-0.instructions.c_fswsp]
+[format-4-0.instructions."c.fswsp"]
 mask = 0xe003
 match = 0xe002
 unsigned = true

--- a/toml/RV32_Zcf.toml
+++ b/toml/RV32_Zcf.toml
@@ -297,22 +297,22 @@ default = "$name$ %rs2_p_Register_float_c%, %himm%(%rs1_p_Register_int_c%)"
 [format-4-0.repr]
 default = "$name$ %c_rs2_Register_float%, %himm%(sp)"
 
-[format-1-0.instructions.c_flw]
+[format-1-0.instructions."c.flw"]
 mask = 0xe003
 match = 0x6000
 unsigned = true
 
-[format-2-0.instructions.c_flwsp]
+[format-2-0.instructions."c.flwsp"]
 mask = 0xe003
 match = 0x6002
 unsigned = true
 
-[format-3-0.instructions.c_fsw]
+[format-3-0.instructions."c.fsw"]
 mask = 0xe003
 match = 0xe000
 unsigned = true
 
-[format-4-0.instructions.c_fswsp]
+[format-4-0.instructions."c.fswsp"]
 mask = 0xe003
 match = 0xe002
 unsigned = true

--- a/toml/RV32_Zfa.toml
+++ b/toml/RV32_Zfa.toml
@@ -379,66 +379,66 @@ default = "$name$ %rd_Register_float%, %lval%"
 [format-3-3.repr]
 default = "$name$ %rd_Register_float%, %rs1_Register_float%, %rm%"
 
-[format-1-3.instructions.fleq_h]
+[format-1-3.instructions."fleq.h"]
 mask = 0xfe00707f
 match = 0xa4004053
 
-[format-1-3.instructions.fleq_s]
+[format-1-3.instructions."fleq.s"]
 mask = 0xfe00707f
 match = 0xa0004053
 
-[format-1-3.instructions.fltq_h]
+[format-1-3.instructions."fltq.h"]
 mask = 0xfe00707f
 match = 0xa4005053
 
-[format-1-3.instructions.fltq_s]
+[format-1-3.instructions."fltq.s"]
 mask = 0xfe00707f
 match = 0xa0005053
 
-[format-1-4.instructions.fmvp_d_x]
+[format-1-4.instructions."fmvp.d.x"]
 mask = 0xfe00707f
 match = 0xb2000053
 
-[format-1-7.instructions.fmaxm_h]
+[format-1-7.instructions."fmaxm.h"]
 mask = 0xfe00707f
 match = 0x2c003053
 
-[format-1-7.instructions.fmaxm_s]
+[format-1-7.instructions."fmaxm.s"]
 mask = 0xfe00707f
 match = 0x28003053
 
-[format-1-7.instructions.fminm_h]
+[format-1-7.instructions."fminm.h"]
 mask = 0xfe00707f
 match = 0x2c002053
 
-[format-1-7.instructions.fminm_s]
+[format-1-7.instructions."fminm.s"]
 mask = 0xfe00707f
 match = 0x28002053
 
-[format-2-2.instructions.fli_h]
+[format-2-2.instructions."fli.h"]
 mask = 0xfff0707f
 match = 0xf4100053
 
-[format-2-2.instructions.fli_s]
+[format-2-2.instructions."fli.s"]
 mask = 0xfff0707f
 match = 0xf0100053
 
-[format-2-1.instructions.fmvh_x_d]
+[format-2-1.instructions."fmvh.x.d"]
 mask = 0xfff0707f
 match = 0xe2100053
 
-[format-3-3.instructions.fround_h]
+[format-3-3.instructions."fround.h"]
 mask = 0xfff0007f
 match = 0x44400053
 
-[format-3-3.instructions.fround_s]
+[format-3-3.instructions."fround.s"]
 mask = 0xfff0007f
 match = 0x40400053
 
-[format-3-3.instructions.froundnx_h]
+[format-3-3.instructions."froundnx.h"]
 mask = 0xfff0007f
 match = 0x44500053
 
-[format-3-3.instructions.froundnx_s]
+[format-3-3.instructions."froundnx.s"]
 mask = 0xfff0007f
 match = 0x40500053

--- a/toml/RV64A.toml
+++ b/toml/RV64A.toml
@@ -214,90 +214,90 @@ default = "$name$%aqrl% %rd_Register_int%, %rs2_Register_int%, (%rs1_Register_in
 [format-2-0.repr]
 default = "$name$%aqrl% %rd_Register_int%, (%rs1_Register_int%)"
 
-[format-1-0.instructions.amoadd_d]
+[format-1-0.instructions."amoadd.d"]
 mask = 0xf800707f
 match = 0x302f
 
-[format-1-0.instructions.amoadd_w]
+[format-1-0.instructions."amoadd.w"]
 mask = 0xf800707f
 match = 0x202f
 
-[format-1-0.instructions.amoand_d]
+[format-1-0.instructions."amoand.d"]
 mask = 0xf800707f
 match = 0x6000302f
 
-[format-1-0.instructions.amoand_w]
+[format-1-0.instructions."amoand.w"]
 mask = 0xf800707f
 match = 0x6000202f
 
-[format-1-0.instructions.amomax_d]
+[format-1-0.instructions."amomax.d"]
 mask = 0xf800707f
 match = 0xa000302f
 
-[format-1-0.instructions.amomax_w]
+[format-1-0.instructions."amomax.w"]
 mask = 0xf800707f
 match = 0xa000202f
 
-[format-1-0.instructions.amomaxu_d]
+[format-1-0.instructions."amomaxu.d"]
 mask = 0xf800707f
 match = 0xe000302f
 
-[format-1-0.instructions.amomaxu_w]
+[format-1-0.instructions."amomaxu.w"]
 mask = 0xf800707f
 match = 0xe000202f
 
-[format-1-0.instructions.amomin_d]
+[format-1-0.instructions."amomin.d"]
 mask = 0xf800707f
 match = 0x8000302f
 
-[format-1-0.instructions.amomin_w]
+[format-1-0.instructions."amomin.w"]
 mask = 0xf800707f
 match = 0x8000202f
 
-[format-1-0.instructions.amominu_d]
+[format-1-0.instructions."amominu.d"]
 mask = 0xf800707f
 match = 0xc000302f
 
-[format-1-0.instructions.amominu_w]
+[format-1-0.instructions."amominu.w"]
 mask = 0xf800707f
 match = 0xc000202f
 
-[format-1-0.instructions.amoor_d]
+[format-1-0.instructions."amoor.d"]
 mask = 0xf800707f
 match = 0x4000302f
 
-[format-1-0.instructions.amoor_w]
+[format-1-0.instructions."amoor.w"]
 mask = 0xf800707f
 match = 0x4000202f
 
-[format-1-0.instructions.amoswap_d]
+[format-1-0.instructions."amoswap.d"]
 mask = 0xf800707f
 match = 0x800302f
 
-[format-1-0.instructions.amoswap_w]
+[format-1-0.instructions."amoswap.w"]
 mask = 0xf800707f
 match = 0x800202f
 
-[format-1-0.instructions.amoxor_d]
+[format-1-0.instructions."amoxor.d"]
 mask = 0xf800707f
 match = 0x2000302f
 
-[format-1-0.instructions.amoxor_w]
+[format-1-0.instructions."amoxor.w"]
 mask = 0xf800707f
 match = 0x2000202f
 
-[format-1-0.instructions.sc_d]
+[format-1-0.instructions."sc.d"]
 mask = 0xf800707f
 match = 0x1800302f
 
-[format-1-0.instructions.sc_w]
+[format-1-0.instructions."sc.w"]
 mask = 0xf800707f
 match = 0x1800202f
 
-[format-2-0.instructions.lr_d]
+[format-2-0.instructions."lr.d"]
 mask = 0xf9f0707f
 match = 0x1000302f
 
-[format-2-0.instructions.lr_w]
+[format-2-0.instructions."lr.w"]
 mask = 0xf9f0707f
 match = 0x1000202f

--- a/toml/RV64C-lower.toml
+++ b/toml/RV64C-lower.toml
@@ -1124,12 +1124,12 @@ default = "$name$ %c_rs2_Register_int%, %himm%(sp)"
 
 [format-23-0.repr]
 default = "$name$ %rd_rs1_n0_Register_int%, %imm%"
-c_slli64 = "$name$ %rd_rs1_n0_Register_int%"
+"c.slli64" = "$name$ %rd_rs1_n0_Register_int%"
 
 [format-24-0.repr]
 default = "$name$ %rd_rs1_p_Register_int_c%, %imm%"
-c_srai64 = "$name$ %rd_rs1_p_Register_int_c%"
-c_srli64 = "$name$ %rd_rs1_p_Register_int_c%"
+"c.srai64" = "$name$ %rd_rs1_p_Register_int_c%"
+"c.srli64" = "$name$ %rd_rs1_p_Register_int_c%"
 
 [format-25-0.repr]
 default = "$name$ %rs2_p_Register_int_c%, %himm%(%rs1_p_Register_int_c%)"
@@ -1137,162 +1137,162 @@ default = "$name$ %rs2_p_Register_int_c%, %himm%(%rs1_p_Register_int_c%)"
 [format-26-0.repr]
 default = "$name$ %c_rs2_Register_int%, %himm%(sp)"
 
-[format-01-0.instructions.c_add]
+[format-01-0.instructions."c.add"]
 mask = 0xf003
 match = 0x9002
 
-[format-02-0.instructions.c_addi]
+[format-02-0.instructions."c.addi"]
 mask = 0xe003
 match = 0x1
 
-[format-33-0.instructions.c_addi16sp]
+[format-33-0.instructions."c.addi16sp"]
 mask = 0xef83
 match = 0x6101
 
-[format-34-0.instructions.c_addi4spn]
+[format-34-0.instructions."c.addi4spn"]
 mask = 0xe003
 match = 0x0
 unsigned = true
 
-[format-05-0.instructions.c_addiw]
+[format-05-0.instructions."c.addiw"]
 mask = 0xe003
 match = 0x2001
 
-[format-06-0.instructions.c_addw]
+[format-06-0.instructions."c.addw"]
 mask = 0xfc63
 match = 0x9c21
 
-[format-06-0.instructions.c_and]
+[format-06-0.instructions."c.and"]
 mask = 0xfc63
 match = 0x8c61
 
-[format-06-0.instructions.c_or]
+[format-06-0.instructions."c.or"]
 mask = 0xfc63
 match = 0x8c41
 
-[format-06-0.instructions.c_sub]
+[format-06-0.instructions."c.sub"]
 mask = 0xfc63
 match = 0x8c01
 
-[format-06-0.instructions.c_subw]
+[format-06-0.instructions."c.subw"]
 mask = 0xfc63
 match = 0x9c01
 
-[format-06-0.instructions.c_xor]
+[format-06-0.instructions."c.xor"]
 mask = 0xfc63
 match = 0x8c21
 
-[format-07-0.instructions.c_andi]
+[format-07-0.instructions."c.andi"]
 mask = 0xec03
 match = 0x8801
 
-[format-08-0.instructions.c_beqz]
+[format-08-0.instructions."c.beqz"]
 mask = 0xe003
 match = 0xc001
 
-[format-08-0.instructions.c_bnez]
+[format-08-0.instructions."c.bnez"]
 mask = 0xe003
 match = 0xe001
 
-[format-29-0.instructions.c_ebreak]
+[format-29-0.instructions."c.ebreak"]
 mask = 0xffff
 match = 0x9002
 
-[format-10-0.instructions.c_j]
+[format-10-0.instructions."c.j"]
 mask = 0xe003
 match = 0xa001
 
-[format-11-0.instructions.c_jalr]
+[format-11-0.instructions."c.jalr"]
 mask = 0xf07f
 match = 0x9002
 
-[format-32-0.instructions.c_jr]
+[format-32-0.instructions."c.jr"]
 mask = 0xf07f
 match = 0x8002
 
-[format-13-0.instructions.c_ld]
+[format-13-0.instructions."c.ld"]
 mask = 0xe003
 match = 0x6000
 unsigned = true
 
-[format-14-0.instructions.c_ldsp]
+[format-14-0.instructions."c.ldsp"]
 mask = 0xe003
 match = 0x6002
 unsigned = true
 
-[format-15-0.instructions.c_li]
+[format-15-0.instructions."c.li"]
 mask = 0xe003
 match = 0x4001
 
-[format-16-0.instructions.c_lui]
+[format-16-0.instructions."c.lui"]
 mask = 0xe003
 match = 0x6001
 unsigned = true
 
-[format-17-0.instructions.c_lw]
+[format-17-0.instructions."c.lw"]
 mask = 0xe003
 match = 0x4000
 unsigned = true
 
-[format-18-0.instructions.c_lwsp]
+[format-18-0.instructions."c.lwsp"]
 mask = 0xe003
 match = 0x4002
 unsigned = true
 
-[format-19-0.instructions.c_mv]
+[format-19-0.instructions."c.mv"]
 mask = 0xf003
 match = 0x8002
 
-[format-20-0.instructions.c_nop]
+[format-20-0.instructions."c.nop"]
 mask = 0xef83
 match = 0x1
 
-[format-21-0.instructions.c_sd]
+[format-21-0.instructions."c.sd"]
 mask = 0xe003
 match = 0xe000
 unsigned = true
 
-[format-22-0.instructions.c_sdsp]
+[format-22-0.instructions."c.sdsp"]
 mask = 0xe003
 match = 0xe002
 unsigned = true
 
-[format-23-0.instructions.c_slli]
+[format-23-0.instructions."c.slli"]
 mask = 0xe003
 match = 0x2
 unsigned = true
 
-[format-23-0.instructions.c_slli64]
+[format-23-0.instructions."c.slli64"]
 mask = 0xf07f
 match = 0x2
 unsigned = true
 
-[format-24-0.instructions.c_srai]
+[format-24-0.instructions."c.srai"]
 mask = 0xec03
 match = 0x8401
 unsigned = true
 
-[format-24-0.instructions.c_srai64]
+[format-24-0.instructions."c.srai64"]
 mask = 0xfc7f
 match = 0x8401
 unsigned = true
 
-[format-24-0.instructions.c_srli]
+[format-24-0.instructions."c.srli"]
 mask = 0xec03
 match = 0x8001
 unsigned = true
 
-[format-24-0.instructions.c_srli64]
+[format-24-0.instructions."c.srli64"]
 mask = 0xfc7f
 match = 0x8001
 unsigned = true
 
-[format-25-0.instructions.c_sw]
+[format-25-0.instructions."c.sw"]
 mask = 0xe003
 match = 0xc000
 unsigned = true
 
-[format-26-0.instructions.c_swsp]
+[format-26-0.instructions."c.swsp"]
 mask = 0xe003
 match = 0xc002
 unsigned = true

--- a/toml/RV64C.toml
+++ b/toml/RV64C.toml
@@ -1124,12 +1124,12 @@ default = "$name$ %c_rs2_Register_int%, %himm%(sp)"
 
 [format-23-0.repr]
 default = "$name$ %rd_rs1_n0_Register_int%, %imm%"
-c_slli64 = "$name$ %rd_rs1_n0_Register_int%"
+"c.slli64" = "$name$ %rd_rs1_n0_Register_int%"
 
 [format-24-0.repr]
 default = "$name$ %rd_rs1_p_Register_int_c%, %imm%"
-c_srai64 = "$name$ %rd_rs1_p_Register_int_c%"
-c_srli64 = "$name$ %rd_rs1_p_Register_int_c%"
+"c.srai64" = "$name$ %rd_rs1_p_Register_int_c%"
+"c.srli64" = "$name$ %rd_rs1_p_Register_int_c%"
 
 [format-25-0.repr]
 default = "$name$ %rs2_p_Register_int_c%, %himm%(%rs1_p_Register_int_c%)"
@@ -1137,162 +1137,162 @@ default = "$name$ %rs2_p_Register_int_c%, %himm%(%rs1_p_Register_int_c%)"
 [format-26-0.repr]
 default = "$name$ %c_rs2_Register_int%, %himm%(sp)"
 
-[format-01-0.instructions.c_add]
+[format-01-0.instructions."c.add"]
 mask = 0xf003
 match = 0x9002
 
-[format-02-0.instructions.c_addi]
+[format-02-0.instructions."c.addi"]
 mask = 0xe003
 match = 0x1
 
-[format-33-0.instructions.c_addi16sp]
+[format-33-0.instructions."c.addi16sp"]
 mask = 0xef83
 match = 0x6101
 
-[format-34-0.instructions.c_addi4spn]
+[format-34-0.instructions."c.addi4spn"]
 mask = 0xe003
 match = 0x0
 unsigned = true
 
-[format-05-0.instructions.c_addiw]
+[format-05-0.instructions."c.addiw"]
 mask = 0xe003
 match = 0x2001
 
-[format-06-0.instructions.c_addw]
+[format-06-0.instructions."c.addw"]
 mask = 0xfc63
 match = 0x9c21
 
-[format-06-0.instructions.c_and]
+[format-06-0.instructions."c.and"]
 mask = 0xfc63
 match = 0x8c61
 
-[format-06-0.instructions.c_or]
+[format-06-0.instructions."c.or"]
 mask = 0xfc63
 match = 0x8c41
 
-[format-06-0.instructions.c_sub]
+[format-06-0.instructions."c.sub"]
 mask = 0xfc63
 match = 0x8c01
 
-[format-06-0.instructions.c_subw]
+[format-06-0.instructions."c.subw"]
 mask = 0xfc63
 match = 0x9c01
 
-[format-06-0.instructions.c_xor]
+[format-06-0.instructions."c.xor"]
 mask = 0xfc63
 match = 0x8c21
 
-[format-07-0.instructions.c_andi]
+[format-07-0.instructions."c.andi"]
 mask = 0xec03
 match = 0x8801
 
-[format-08-0.instructions.c_beqz]
+[format-08-0.instructions."c.beqz"]
 mask = 0xe003
 match = 0xc001
 
-[format-08-0.instructions.c_bnez]
+[format-08-0.instructions."c.bnez"]
 mask = 0xe003
 match = 0xe001
 
-[format-29-0.instructions.c_ebreak]
+[format-29-0.instructions."c.ebreak"]
 mask = 0xffff
 match = 0x9002
 
-[format-10-0.instructions.c_j]
+[format-10-0.instructions."c.j"]
 mask = 0xe003
 match = 0xa001
 
-[format-11-0.instructions.c_jalr]
+[format-11-0.instructions."c.jalr"]
 mask = 0xf07f
 match = 0x9002
 
-[format-32-0.instructions.c_jr]
+[format-32-0.instructions."c.jr"]
 mask = 0xf07f
 match = 0x8002
 
-[format-13-0.instructions.c_ld]
+[format-13-0.instructions."c.ld"]
 mask = 0xe003
 match = 0x6000
 unsigned = true
 
-[format-14-0.instructions.c_ldsp]
+[format-14-0.instructions."c.ldsp"]
 mask = 0xe003
 match = 0x6002
 unsigned = true
 
-[format-15-0.instructions.c_li]
+[format-15-0.instructions."c.li"]
 mask = 0xe003
 match = 0x4001
 
-[format-16-0.instructions.c_lui]
+[format-16-0.instructions."c.lui"]
 mask = 0xe003
 match = 0x6001
 unsigned = true
 
-[format-17-0.instructions.c_lw]
+[format-17-0.instructions."c.lw"]
 mask = 0xe003
 match = 0x4000
 unsigned = true
 
-[format-18-0.instructions.c_lwsp]
+[format-18-0.instructions."c.lwsp"]
 mask = 0xe003
 match = 0x4002
 unsigned = true
 
-[format-19-0.instructions.c_mv]
+[format-19-0.instructions."c.mv"]
 mask = 0xf003
 match = 0x8002
 
-[format-20-0.instructions.c_nop]
+[format-20-0.instructions."c.nop"]
 mask = 0xef83
 match = 0x1
 
-[format-21-0.instructions.c_sd]
+[format-21-0.instructions."c.sd"]
 mask = 0xe003
 match = 0xe000
 unsigned = true
 
-[format-22-0.instructions.c_sdsp]
+[format-22-0.instructions."c.sdsp"]
 mask = 0xe003
 match = 0xe002
 unsigned = true
 
-[format-23-0.instructions.c_slli]
+[format-23-0.instructions."c.slli"]
 mask = 0xe003
 match = 0x2
 unsigned = true
 
-[format-23-0.instructions.c_slli64]
+[format-23-0.instructions."c.slli64"]
 mask = 0xf07f
 match = 0x2
 unsigned = true
 
-[format-24-0.instructions.c_srai]
+[format-24-0.instructions."c.srai"]
 mask = 0xec03
 match = 0x8401
 unsigned = true
 
-[format-24-0.instructions.c_srai64]
+[format-24-0.instructions."c.srai64"]
 mask = 0xfc7f
 match = 0x8401
 unsigned = true
 
-[format-24-0.instructions.c_srli]
+[format-24-0.instructions."c.srli"]
 mask = 0xec03
 match = 0x8001
 unsigned = true
 
-[format-24-0.instructions.c_srli64]
+[format-24-0.instructions."c.srli64"]
 mask = 0xfc7f
 match = 0x8001
 unsigned = true
 
-[format-25-0.instructions.c_sw]
+[format-25-0.instructions."c.sw"]
 mask = 0xe003
 match = 0xc000
 unsigned = true
 
-[format-26-0.instructions.c_swsp]
+[format-26-0.instructions."c.swsp"]
 mask = 0xe003
 match = 0xc002
 unsigned = true

--- a/toml/RV64D.toml
+++ b/toml/RV64D.toml
@@ -537,107 +537,107 @@ default = "$name$ %rd_Register_float%, %rs1_Register_float%, %rs2_Register_float
 [format-7-0.repr]
 default = "$name$ %rs2_Register_float%, %imm%(%rs1_Register_int%)"
 
-[format-1-7.instructions.fadd_d]
+[format-1-7.instructions."fadd.d"]
 mask = 0xfe00007f
 match = 0x2000053
 
-[format-1-7.instructions.fdiv_d]
+[format-1-7.instructions."fdiv.d"]
 mask = 0xfe00007f
 match = 0x1a000053
 
-[format-1-7.instructions.fmul_d]
+[format-1-7.instructions."fmul.d"]
 mask = 0xfe00007f
 match = 0x12000053
 
-[format-1-7.instructions.fsub_d]
+[format-1-7.instructions."fsub.d"]
 mask = 0xfe00007f
 match = 0xa000053
 
-[format-2-1.instructions.fclass_d]
+[format-2-1.instructions."fclass.d"]
 mask = 0xfff0707f
 match = 0xe2001053
 
-[format-2-1.instructions.fmv_x_d]
+[format-2-1.instructions."fmv.x.d"]
 mask = 0xfff0707f
 match = 0xe2000053
 
-[format-2-2.instructions.fmv_d_x]
+[format-2-2.instructions."fmv.d.x"]
 mask = 0xfff0707f
 match = 0xf2000053
 
-[format-3-1.instructions.fcvt_l_d]
+[format-3-1.instructions."fcvt.l.d"]
 mask = 0xfff0007f
 match = 0xc2200053
 
-[format-3-1.instructions.fcvt_lu_d]
+[format-3-1.instructions."fcvt.lu.d"]
 mask = 0xfff0007f
 match = 0xc2300053
 
-[format-3-1.instructions.fcvt_w_d]
+[format-3-1.instructions."fcvt.w.d"]
 mask = 0xfff0007f
 match = 0xc2000053
 
-[format-3-1.instructions.fcvt_wu_d]
+[format-3-1.instructions."fcvt.wu.d"]
 mask = 0xfff0007f
 match = 0xc2100053
 
-[format-3-2.instructions.fcvt_d_l]
+[format-3-2.instructions."fcvt.d.l"]
 mask = 0xfff0007f
 match = 0xd2200053
 
-[format-3-2.instructions.fcvt_d_lu]
+[format-3-2.instructions."fcvt.d.lu"]
 mask = 0xfff0007f
 match = 0xd2300053
 
-[format-3-2.instructions.fcvt_d_w]
+[format-3-2.instructions."fcvt.d.w"]
 mask = 0xfff0007f
 match = 0xd2000053
 
-[format-3-2.instructions.fcvt_d_wu]
+[format-3-2.instructions."fcvt.d.wu"]
 mask = 0xfff0007f
 match = 0xd2100053
 
-[format-3-3.instructions.fcvt_d_s]
+[format-3-3.instructions."fcvt.d.s"]
 mask = 0xfff0007f
 match = 0x42000053
 
-[format-3-3.instructions.fcvt_s_d]
+[format-3-3.instructions."fcvt.s.d"]
 mask = 0xfff0007f
 match = 0x40100053
 
-[format-3-3.instructions.fsqrt_d]
+[format-3-3.instructions."fsqrt.d"]
 mask = 0xfff0007f
 match = 0x5a000053
 
-[format-4-3.instructions.feq_d]
+[format-4-3.instructions."feq.d"]
 mask = 0xfe00707f
 match = 0xa2002053
 
-[format-4-3.instructions.fle_d]
+[format-4-3.instructions."fle.d"]
 mask = 0xfe00707f
 match = 0xa2000053
 
-[format-4-3.instructions.flt_d]
+[format-4-3.instructions."flt.d"]
 mask = 0xfe00707f
 match = 0xa2001053
 
-[format-4-7.instructions.fmax_d]
+[format-4-7.instructions."fmax.d"]
 mask = 0xfe00707f
 match = 0x2a001053
 
-[format-4-7.instructions.fmin_d]
+[format-4-7.instructions."fmin.d"]
 mask = 0xfe00707f
 match = 0x2a000053
 
-[format-4-7.instructions.fsgnj_d]
+[format-4-7.instructions."fsgnj.d"]
 mask = 0xfe00707f
 match = 0x22000053
 
-[format-4-7.instructions.fsgnjn_d]
+[format-4-7.instructions."fsgnjn.d"]
 mask = 0xfe00707f
 match = 0x22001053
 
-[format-4-7.instructions.fsgnjx_d]
+[format-4-7.instructions."fsgnjx.d"]
 mask = 0xfe00707f
 match = 0x22002053
 
@@ -645,19 +645,19 @@ match = 0x22002053
 mask = 0x707f
 match = 0x3007
 
-[format-6-15.instructions.fmadd_d]
+[format-6-15.instructions."fmadd.d"]
 mask = 0x600007f
 match = 0x2000043
 
-[format-6-15.instructions.fmsub_d]
+[format-6-15.instructions."fmsub.d"]
 mask = 0x600007f
 match = 0x2000047
 
-[format-6-15.instructions.fnmadd_d]
+[format-6-15.instructions."fnmadd.d"]
 mask = 0x600007f
 match = 0x200004f
 
-[format-6-15.instructions.fnmsub_d]
+[format-6-15.instructions."fnmsub.d"]
 mask = 0x600007f
 match = 0x200004b
 

--- a/toml/RV64_Zacas.toml
+++ b/toml/RV64_Zacas.toml
@@ -173,14 +173,14 @@ Mapping_ordering = ["", ".rl", ".aq", ".aqrl"]
 [format-1-0.repr]
 default = "$name$%aqrl% %rd_Register_int%, %rs2_Register_int%, (%rs1_Register_int%)"
 
-[format-1-0.instructions.amocas_d]
+[format-1-0.instructions."amocas.d"]
 mask = 0xf800707f
 match = 0x2800302f
 
-[format-1-0.instructions.amocas_q]
+[format-1-0.instructions."amocas.q"]
 mask = 0xf800707f
 match = 0x2800402f
 
-[format-1-0.instructions.amocas_w]
+[format-1-0.instructions."amocas.w"]
 mask = 0xf800707f
 match = 0x2800202f

--- a/toml/RV64_Zbb.toml
+++ b/toml/RV64_Zbb.toml
@@ -345,7 +345,7 @@ match = 0x60101013
 mask = 0xfff0707f
 match = 0x6010101b
 
-[format_2-0.instructions.orc_b]
+[format_2-0.instructions."orc.b"]
 mask = 0xfff0707f
 match = 0x28705013
 
@@ -353,15 +353,15 @@ match = 0x28705013
 mask = 0xfff0707f
 match = 0x6b805013
 
-[format_2-0.instructions.sext_b]
+[format_2-0.instructions."sext.b"]
 mask = 0xfff0707f
 match = 0x60401013
 
-[format_2-0.instructions.sext_h]
+[format_2-0.instructions."sext.h"]
 mask = 0xfff0707f
 match = 0x60501013
 
-[format_2-0.instructions.zext_h]
+[format_2-0.instructions."zext.h"]
 mask = 0xfff0707f
 match = 0x800403b
 

--- a/toml/RV64_Zcb-lower.toml
+++ b/toml/RV64_Zcb-lower.toml
@@ -273,55 +273,55 @@ default = "$name$ %rs2_p_Register_int_c%, %himm%(%rs1_p_Register_int_c%)"
 [format-6-0.repr]
 default = "$name$ %rs2_p_Register_int_c%, %himm%(%rs1_p_Register_int_c%)"
 
-[format-1-0.instructions.c_lbu]
+[format-1-0.instructions."c.lbu"]
 mask = 0xfc03
 match = 0x8000
 unsigned = true
 
-[format-2-0.instructions.c_lh]
+[format-2-0.instructions."c.lh"]
 mask = 0xfc43
 match = 0x8440
 unsigned = true
 
-[format-2-0.instructions.c_lhu]
+[format-2-0.instructions."c.lhu"]
 mask = 0xfc43
 match = 0x8400
 unsigned = true
 
-[format-3-0.instructions.c_mul]
+[format-3-0.instructions."c.mul"]
 mask = 0xfc63
 match = 0x9c41
 
-[format-4-0.instructions.c_not]
+[format-4-0.instructions."c.not"]
 mask = 0xfc7f
 match = 0x9c75
 
-[format-4-0.instructions.c_sext_b]
+[format-4-0.instructions."c.sext.b"]
 mask = 0xfc7f
 match = 0x9c65
 
-[format-4-0.instructions.c_sext_h]
+[format-4-0.instructions."c.sext.h"]
 mask = 0xfc7f
 match = 0x9c6d
 
-[format-4-0.instructions.c_zext_b]
+[format-4-0.instructions."c.zext.b"]
 mask = 0xfc7f
 match = 0x9c61
 
-[format-4-0.instructions.c_zext_h]
+[format-4-0.instructions."c.zext.h"]
 mask = 0xfc7f
 match = 0x9c69
 
-[format-4-0.instructions.c_zext_w]
+[format-4-0.instructions."c.zext.w"]
 mask = 0xfc7f
 match = 0x9c71
 
-[format-5-0.instructions.c_sb]
+[format-5-0.instructions."c.sb"]
 mask = 0xfc03
 match = 0x8800
 unsigned = true
 
-[format-6-0.instructions.c_sh]
+[format-6-0.instructions."c.sh"]
 mask = 0xfc43
 match = 0x8c00
 unsigned = true

--- a/toml/RV64_Zcb.toml
+++ b/toml/RV64_Zcb.toml
@@ -273,55 +273,55 @@ default = "$name$ %rs2_p_Register_int_c%, %himm%(%rs1_p_Register_int_c%)"
 [format-6-0.repr]
 default = "$name$ %rs2_p_Register_int_c%, %himm%(%rs1_p_Register_int_c%)"
 
-[format-1-0.instructions.c_lbu]
+[format-1-0.instructions."c.lbu"]
 mask = 0xfc03
 match = 0x8000
 unsigned = true
 
-[format-2-0.instructions.c_lh]
+[format-2-0.instructions."c.lh"]
 mask = 0xfc43
 match = 0x8440
 unsigned = true
 
-[format-2-0.instructions.c_lhu]
+[format-2-0.instructions."c.lhu"]
 mask = 0xfc43
 match = 0x8400
 unsigned = true
 
-[format-3-0.instructions.c_mul]
+[format-3-0.instructions."c.mul"]
 mask = 0xfc63
 match = 0x9c41
 
-[format-4-0.instructions.c_not]
+[format-4-0.instructions."c.not"]
 mask = 0xfc7f
 match = 0x9c75
 
-[format-4-0.instructions.c_sext_b]
+[format-4-0.instructions."c.sext.b"]
 mask = 0xfc7f
 match = 0x9c65
 
-[format-4-0.instructions.c_sext_h]
+[format-4-0.instructions."c.sext.h"]
 mask = 0xfc7f
 match = 0x9c6d
 
-[format-4-0.instructions.c_zext_b]
+[format-4-0.instructions."c.zext.b"]
 mask = 0xfc7f
 match = 0x9c61
 
-[format-4-0.instructions.c_zext_h]
+[format-4-0.instructions."c.zext.h"]
 mask = 0xfc7f
 match = 0x9c69
 
-[format-4-0.instructions.c_zext_w]
+[format-4-0.instructions."c.zext.w"]
 mask = 0xfc7f
 match = 0x9c71
 
-[format-5-0.instructions.c_sb]
+[format-5-0.instructions."c.sb"]
 mask = 0xfc03
 match = 0x8800
 unsigned = true
 
-[format-6-0.instructions.c_sh]
+[format-6-0.instructions."c.sh"]
 mask = 0xfc43
 match = 0x8c00
 unsigned = true

--- a/toml/RV64_Zcd-lower.toml
+++ b/toml/RV64_Zcd-lower.toml
@@ -287,22 +287,22 @@ default = "$name$ %rs2_p_Register_float_c%, %himm%(%rs1_p_Register_int_c%)"
 [format-4-1.repr]
 default = "$name$ %c_rs2_Register_float%, %himm%(sp)"
 
-[format-1-0.instructions.c_fld]
+[format-1-0.instructions."c.fld"]
 mask = 0xe003
 match = 0x2000
 unsigned = true
 
-[format-2-1.instructions.c_fldsp]
+[format-2-1.instructions."c.fldsp"]
 mask = 0xe003
 match = 0x2002
 unsigned = true
 
-[format-3-0.instructions.c_fsd]
+[format-3-0.instructions."c.fsd"]
 mask = 0xe003
 match = 0xa000
 unsigned = true
 
-[format-4-1.instructions.c_fsdsp]
+[format-4-1.instructions."c.fsdsp"]
 mask = 0xe003
 match = 0xa002
 unsigned = true

--- a/toml/RV64_Zcd.toml
+++ b/toml/RV64_Zcd.toml
@@ -287,22 +287,22 @@ default = "$name$ %rs2_p_Register_float_c%, %himm%(%rs1_p_Register_int_c%)"
 [format-4-1.repr]
 default = "$name$ %c_rs2_Register_float%, %himm%(sp)"
 
-[format-1-0.instructions.c_fld]
+[format-1-0.instructions."c.fld"]
 mask = 0xe003
 match = 0x2000
 unsigned = true
 
-[format-2-1.instructions.c_fldsp]
+[format-2-1.instructions."c.fldsp"]
 mask = 0xe003
 match = 0x2002
 unsigned = true
 
-[format-3-0.instructions.c_fsd]
+[format-3-0.instructions."c.fsd"]
 mask = 0xe003
 match = 0xa000
 unsigned = true
 
-[format-4-1.instructions.c_fsdsp]
+[format-4-1.instructions."c.fsdsp"]
 mask = 0xe003
 match = 0xa002
 unsigned = true

--- a/toml/RV64_Zfa.toml
+++ b/toml/RV64_Zfa.toml
@@ -336,62 +336,62 @@ default = "$name$ %rd_Register_float%, %rs1_Register_float%, %rs2_Register_float
 [format-3-3.repr]
 default = "$name$ %rd_Register_float%, %rs1_Register_float%, %rm%"
 
-[format-1-1.instructions.fcvtmod_w_d]
+[format-1-1.instructions."fcvtmod.w.d"]
 mask = 0xfff0707f
 match = 0xc2801053
 
-[format-1-2.instructions.fli_d]
+[format-1-2.instructions."fli.d"]
 mask = 0xfff0707f
 match = 0xf2100053
 
-[format-1-2.instructions.fli_h]
+[format-1-2.instructions."fli.h"]
 mask = 0xfff0707f
 match = 0xf4100053
 
-[format-2-3.instructions.fleq_d]
+[format-2-3.instructions."fleq.d"]
 mask = 0xfe00707f
 match = 0xa2004053
 
-[format-2-3.instructions.fleq_h]
+[format-2-3.instructions."fleq.h"]
 mask = 0xfe00707f
 match = 0xa4004053
 
-[format-2-3.instructions.fltq_d]
+[format-2-3.instructions."fltq.d"]
 mask = 0xfe00707f
 match = 0xa2005053
 
-[format-2-3.instructions.fltq_h]
+[format-2-3.instructions."fltq.h"]
 mask = 0xfe00707f
 match = 0xa4005053
 
-[format-2-7.instructions.fmaxm_d]
+[format-2-7.instructions."fmaxm.d"]
 mask = 0xfe00707f
 match = 0x2a003053
 
-[format-2-7.instructions.fmaxm_h]
+[format-2-7.instructions."fmaxm.h"]
 mask = 0xfe00707f
 match = 0x2c003053
 
-[format-2-7.instructions.fminm_d]
+[format-2-7.instructions."fminm.d"]
 mask = 0xfe00707f
 match = 0x2a002053
 
-[format-2-7.instructions.fminm_h]
+[format-2-7.instructions."fminm.h"]
 mask = 0xfe00707f
 match = 0x2c002053
 
-[format-3-3.instructions.fround_d]
+[format-3-3.instructions."fround.d"]
 mask = 0xfff0007f
 match = 0x42400053
 
-[format-3-3.instructions.fround_h]
+[format-3-3.instructions."fround.h"]
 mask = 0xfff0007f
 match = 0x44400053
 
-[format-3-3.instructions.froundnx_d]
+[format-3-3.instructions."froundnx.d"]
 mask = 0xfff0007f
 match = 0x42500053
 
-[format-3-3.instructions.froundnx_h]
+[format-3-3.instructions."froundnx.h"]
 mask = 0xfff0007f
 match = 0x44500053

--- a/toml/RVV.toml
+++ b/toml/RVV.toml
@@ -1228,68 +1228,68 @@ Mapping_seg = ["", "seg2", "seg3", "seg4", "seg5", "seg6", "seg7", "seg8"]
 
 [format_1-0.repr]
 default = "$name$ %vd%, %vs2%, %vs1%%vm%"
-vfmacc_vv = "$name$ %vd%, %vs1%, %vs2%%vm%"
-vfmadd_vv = "$name$ %vd%, %vs1%, %vs2%%vm%"
-vfmsac_vv = "$name$ %vd%, %vs1%, %vs2%%vm%"
-vfmsub_vv = "$name$ %vd%, %vs1%, %vs2%%vm%"
-vfnmacc_vv = "$name$ %vd%, %vs1%, %vs2%%vm%"
-vfnmadd_vv = "$name$ %vd%, %vs1%, %vs2%%vm%"
-vfnmsac_vv = "$name$ %vd%, %vs1%, %vs2%%vm%"
-vfnmsub_vv = "$name$ %vd%, %vs1%, %vs2%%vm%"
-vfwmacc_vv = "$name$ %vd%, %vs1%, %vs2%%vm%"
-vfwmsac_vv = "$name$ %vd%, %vs1%, %vs2%%vm%"
-vfwnmacc_vv = "$name$ %vd%, %vs1%, %vs2%%vm%"
-vfwnmsac_vv = "$name$ %vd%, %vs1%, %vs2%%vm%"
-vmacc_vv = "$name$ %vd%, %vs1%, %vs2%%vm%"
-vmadd_vv = "$name$ %vd%, %vs1%, %vs2%%vm%"
-vnmsac_vv = "$name$ %vd%, %vs1%, %vs2%%vm%"
-vnmsub_vv = "$name$ %vd%, %vs1%, %vs2%%vm%"
-vwmacc_vv = "$name$ %vd%, %vs1%, %vs2%%vm%"
-vwmaccsu_vv = "$name$ %vd%, %vs1%, %vs2%%vm%"
-vwmaccu_vv = "$name$ %vd%, %vs1%, %vs2%%vm%"
+"vfmacc.vv" = "$name$ %vd%, %vs1%, %vs2%%vm%"
+"vfmadd.vv" = "$name$ %vd%, %vs1%, %vs2%%vm%"
+"vfmsac.vv" = "$name$ %vd%, %vs1%, %vs2%%vm%"
+"vfmsub.vv" = "$name$ %vd%, %vs1%, %vs2%%vm%"
+"vfnmacc.vv" = "$name$ %vd%, %vs1%, %vs2%%vm%"
+"vfnmadd.vv" = "$name$ %vd%, %vs1%, %vs2%%vm%"
+"vfnmsac.vv" = "$name$ %vd%, %vs1%, %vs2%%vm%"
+"vfnmsub.vv" = "$name$ %vd%, %vs1%, %vs2%%vm%"
+"vfwmacc.vv" = "$name$ %vd%, %vs1%, %vs2%%vm%"
+"vfwmsac.vv" = "$name$ %vd%, %vs1%, %vs2%%vm%"
+"vfwnmacc.vv" = "$name$ %vd%, %vs1%, %vs2%%vm%"
+"vfwnmsac.vv" = "$name$ %vd%, %vs1%, %vs2%%vm%"
+"vmacc.vv" = "$name$ %vd%, %vs1%, %vs2%%vm%"
+"vmadd.vv" = "$name$ %vd%, %vs1%, %vs2%%vm%"
+"vnmsac.vv" = "$name$ %vd%, %vs1%, %vs2%%vm%"
+"vnmsub.vv" = "$name$ %vd%, %vs1%, %vs2%%vm%"
+"vwmacc.vv" = "$name$ %vd%, %vs1%, %vs2%%vm%"
+"vwmaccsu.vv" = "$name$ %vd%, %vs1%, %vs2%%vm%"
+"vwmaccu.vv" = "$name$ %vd%, %vs1%, %vs2%%vm%"
 
 [format_2-0.repr]
 default = "$name$ %vd%, %vs2%, %rs1_Register_int%%vm%"
-vmacc_vx = "$name$ %vd%, %rs1_Register_int%, %vs2%%vm%"
-vmadd_vx = "$name$ %vd%, %rs1_Register_int%, %vs2%%vm%"
-vnmsac_vx = "$name$ %vd%, %rs1_Register_int%, %vs2%%vm%"
-vnmsub_vx = "$name$ %vd%, %rs1_Register_int%, %vs2%%vm%"
-vwmacc_vx = "$name$ %vd%, %rs1_Register_int%, %vs2%%vm%"
-vwmaccsu_vx = "$name$ %vd%, %rs1_Register_int%, %vs2%%vm%"
-vwmaccu_vx = "$name$ %vd%, %rs1_Register_int%, %vs2%%vm%"
-vwmaccus_vx = "$name$ %vd%, %rs1_Register_int%, %vs2%%vm%"
+"vmacc.vx" = "$name$ %vd%, %rs1_Register_int%, %vs2%%vm%"
+"vmadd.vx" = "$name$ %vd%, %rs1_Register_int%, %vs2%%vm%"
+"vnmsac.vx" = "$name$ %vd%, %rs1_Register_int%, %vs2%%vm%"
+"vnmsub.vx" = "$name$ %vd%, %rs1_Register_int%, %vs2%%vm%"
+"vwmacc.vx" = "$name$ %vd%, %rs1_Register_int%, %vs2%%vm%"
+"vwmaccsu.vx" = "$name$ %vd%, %rs1_Register_int%, %vs2%%vm%"
+"vwmaccu.vx" = "$name$ %vd%, %rs1_Register_int%, %vs2%%vm%"
+"vwmaccus.vx" = "$name$ %vd%, %rs1_Register_int%, %vs2%%vm%"
 
 [format_2-1.repr]
 default = "$name$ %vd%, %vs2%, %rs1_Register_float%%vm%"
-vfmacc_vf = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
-vfmadd_vf = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
-vfmsac_vf = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
-vfmsub_vf = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
-vfnmacc_vf = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
-vfnmadd_vf = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
-vfnmsac_vf = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
-vfnmsub_vf = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
-vfwmacc_vf = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
-vfwmsac_vf = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
-vfwnmacc_vf = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
-vfwnmsac_vf = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
+"vfmacc.vf" = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
+"vfmadd.vf" = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
+"vfmsac.vf" = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
+"vfmsub.vf" = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
+"vfnmacc.vf" = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
+"vfnmadd.vf" = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
+"vfnmsac.vf" = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
+"vfnmsub.vf" = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
+"vfwmacc.vf" = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
+"vfwmsac.vf" = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
+"vfwnmacc.vf" = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
+"vfwnmsac.vf" = "$name$ %vd%, %rs1_Register_float%, %vs2%%vm%"
 
 [format_3-0.repr]
 default = "$name$ %vd%, %vs2%, %himm%, v0"
-vmadc_vi = "$name$ %vd%, %vs2%, %himm%"
+"vmadc.vi" = "$name$ %vd%, %vs2%, %himm%"
 
 [format_4-0.repr]
 default = "$name$ %vd%, %vs2%, %vs1%"
-vadc_vvm = "$name$ %vd%, %vs2%, %vs1%, v0"
-vmadc_vvm = "$name$ %vd%, %vs2%, %vs1%, v0"
-vmerge_vvm = "$name$ %vd%, %vs2%, %vs1%, v0"
-vmsbc_vvm = "$name$ %vd%, %vs2%, %vs1%, v0"
-vsbc_vvm = "$name$ %vd%, %vs2%, %vs1%, v0"
+"vadc.vvm" = "$name$ %vd%, %vs2%, %vs1%, v0"
+"vmadc.vvm" = "$name$ %vd%, %vs2%, %vs1%, v0"
+"vmerge.vvm" = "$name$ %vd%, %vs2%, %vs1%, v0"
+"vmsbc.vvm" = "$name$ %vd%, %vs2%, %vs1%, v0"
+"vsbc.vvm" = "$name$ %vd%, %vs2%, %vs1%, v0"
 
 [format_5-0.repr]
 default = "$name$ %vd%, %vs2%, %rs1_Register_int%, v0"
-vmadc_vx = "$name$ %vd%, %vs2%, %rs1_Register_int%"
-vmsbc_vx = "$name$ %vd%, %vs2%, %rs1_Register_int%"
+"vmadc.vx" = "$name$ %vd%, %vs2%, %rs1_Register_int%"
+"vmsbc.vx" = "$name$ %vd%, %vs2%, %rs1_Register_int%"
 
 [format_5-1.repr]
 default = "$name$ %vd%, %vs2%, %rs1_Register_float%, v0"
@@ -1311,8 +1311,8 @@ default = "$name$ %rd_Register_float%, %vs2%"
 
 [format_10-0.repr]
 default = "$name$ %vd%, (%rs1_Register_int%)"
-vmv_s_x = "$name$ %vd%, %rs1_Register_int%"
-vmv_v_x = "$name$ %vd%, %rs1_Register_int%"
+"vmv.s.x" = "$name$ %vd%, %rs1_Register_int%"
+"vmv.v.x" = "$name$ %vd%, %rs1_Register_int%"
 
 [format_10-1.repr]
 default = "$name$ %vd%, %rs1_Register_float%"
@@ -1322,29 +1322,29 @@ default = "$name$ %vd%%vm%"
 
 [format_12-0.repr]
 default = "vl%nf%e16.v %vd%, (%rs1_Register_int%)%vm%"
-vle16ff_v = "vl%nf%e16ff.v %vd%, (%rs1_Register_int%)%vm%"
-vle32_v = "vl%nf%e32.v %vd%, (%rs1_Register_int%)%vm%"
-vle32ff_v = "vl%nf%e32ff.v %vd%, (%rs1_Register_int%)%vm%"
-vle64_v = "vl%nf%e64.v %vd%, (%rs1_Register_int%)%vm%"
-vle64ff_v = "vl%nf%e64ff.v %vd%, (%rs1_Register_int%)%vm%"
-vle8_v = "vl%nf%e8.v %vd%, (%rs1_Register_int%)%vm%"
-vle8ff_v = "vl%nf%e8ff.v %vd%, (%rs1_Register_int%)%vm%"
+"vle16ff.v" = "vl%nf%e16ff.v %vd%, (%rs1_Register_int%)%vm%"
+"vle32.v" = "vl%nf%e32.v %vd%, (%rs1_Register_int%)%vm%"
+"vle32ff.v" = "vl%nf%e32ff.v %vd%, (%rs1_Register_int%)%vm%"
+"vle64.v" = "vl%nf%e64.v %vd%, (%rs1_Register_int%)%vm%"
+"vle64ff.v" = "vl%nf%e64ff.v %vd%, (%rs1_Register_int%)%vm%"
+"vle8.v" = "vl%nf%e8.v %vd%, (%rs1_Register_int%)%vm%"
+"vle8ff.v" = "vl%nf%e8ff.v %vd%, (%rs1_Register_int%)%vm%"
 
 [format_13-0.repr]
 default = "vlox%nf%ei16.v %vd%, (%rs1_Register_int%), %vs2%%vm%"
-vloxei32_v = "vlox%nf%ei32.v %vd%, (%rs1_Register_int%), %vs2%%vm%"
-vloxei64_v = "vlox%nf%ei64.v %vd%, (%rs1_Register_int%), %vs2%%vm%"
-vloxei8_v = "vlox%nf%ei8.v %vd%, (%rs1_Register_int%), %vs2%%vm%"
-vluxei16_v = "vlux%nf%ei16.v %vd%, (%rs1_Register_int%), %vs2%%vm%"
-vluxei32_v = "vlux%nf%ei32.v %vd%, (%rs1_Register_int%), %vs2%%vm%"
-vluxei64_v = "vlux%nf%ei64.v %vd%, (%rs1_Register_int%), %vs2%%vm%"
-vluxei8_v = "vlux%nf%ei8.v %vd%, (%rs1_Register_int%), %vs2%%vm%"
+"vloxei32.v" = "vlox%nf%ei32.v %vd%, (%rs1_Register_int%), %vs2%%vm%"
+"vloxei64.v" = "vlox%nf%ei64.v %vd%, (%rs1_Register_int%), %vs2%%vm%"
+"vloxei8.v" = "vlox%nf%ei8.v %vd%, (%rs1_Register_int%), %vs2%%vm%"
+"vluxei16.v" = "vlux%nf%ei16.v %vd%, (%rs1_Register_int%), %vs2%%vm%"
+"vluxei32.v" = "vlux%nf%ei32.v %vd%, (%rs1_Register_int%), %vs2%%vm%"
+"vluxei64.v" = "vlux%nf%ei64.v %vd%, (%rs1_Register_int%), %vs2%%vm%"
+"vluxei8.v" = "vlux%nf%ei8.v %vd%, (%rs1_Register_int%), %vs2%%vm%"
 
 [format_14-0.repr]
 default = "vls%nf%e16.v %vd%, (%rs1_Register_int%), %rs2_Register_int%%vm%"
-vlse32_v = "vls%nf%e32.v %vd%, (%rs1_Register_int%), %rs2_Register_int%%vm%"
-vlse64_v = "vls%nf%e64.v %vd%, (%rs1_Register_int%), %rs2_Register_int%%vm%"
-vlse8_v = "vls%nf%e8.v %vd%, (%rs1_Register_int%), %rs2_Register_int%%vm%"
+"vlse32.v" = "vls%nf%e32.v %vd%, (%rs1_Register_int%), %rs2_Register_int%%vm%"
+"vlse64.v" = "vls%nf%e64.v %vd%, (%rs1_Register_int%), %rs2_Register_int%%vm%"
+"vlse8.v" = "vls%nf%e8.v %vd%, (%rs1_Register_int%), %rs2_Register_int%%vm%"
 
 [format_15-0.repr]
 default = "$name$ %vd%, %vs2%"
@@ -1360,9 +1360,9 @@ default = "$name$ %vs3%, (%rs1_Register_int%)"
 
 [format_19-0.repr]
 default = "vs%nf%e16.v %vs3%, (%rs1_Register_int%)%vm%"
-vse32_v = "vs%nf%e32.v %vs3%, (%rs1_Register_int%)%vm%"
-vse64_v = "vs%nf%e64.v %vs3%, (%rs1_Register_int%)%vm%"
-vse8_v = "vs%nf%e8.v %vs3%, (%rs1_Register_int%)%vm%"
+"vse32.v" = "vs%nf%e32.v %vs3%, (%rs1_Register_int%)%vm%"
+"vse64.v" = "vs%nf%e64.v %vs3%, (%rs1_Register_int%)%vm%"
+"vse8.v" = "vs%nf%e8.v %vs3%, (%rs1_Register_int%)%vm%"
 
 [format_20-0.repr]
 default = "$name$ %rd_Register_int%, %himm%, %zimm10%"
@@ -1375,19 +1375,19 @@ default = "$name$ %rd_Register_int%, %rs1_Register_int%, %zimm11%"
 
 [format_23-0.repr]
 default = "vsox%nf%ei16.v %vs3%, (%rs1_Register_int%), %vs2%%vm%"
-vsoxei32_v = "vsox%nf%ei32.v %vs3%, (%rs1_Register_int%), %vs2%%vm%"
-vsoxei64_v = "vsox%nf%ei64.v %vs3%, (%rs1_Register_int%), %vs2%%vm%"
-vsoxei8_v = "vsox%nf%ei8.v %vs3%, (%rs1_Register_int%), %vs2%%vm%"
-vsuxei16_v = "vsux%nf%ei16.v %vs3%, (%rs1_Register_int%), %vs2%%vm%"
-vsuxei32_v = "vsux%nf%ei32.v %vs3%, (%rs1_Register_int%), %vs2%%vm%"
-vsuxei64_v = "vsux%nf%ei64.v %vs3%, (%rs1_Register_int%), %vs2%%vm%"
-vsuxei8_v = "vsux%nf%ei8.v %vs3%, (%rs1_Register_int%), %vs2%%vm%"
+"vsoxei32.v" = "vsox%nf%ei32.v %vs3%, (%rs1_Register_int%), %vs2%%vm%"
+"vsoxei64.v" = "vsox%nf%ei64.v %vs3%, (%rs1_Register_int%), %vs2%%vm%"
+"vsoxei8.v" = "vsox%nf%ei8.v %vs3%, (%rs1_Register_int%), %vs2%%vm%"
+"vsuxei16.v" = "vsux%nf%ei16.v %vs3%, (%rs1_Register_int%), %vs2%%vm%"
+"vsuxei32.v" = "vsux%nf%ei32.v %vs3%, (%rs1_Register_int%), %vs2%%vm%"
+"vsuxei64.v" = "vsux%nf%ei64.v %vs3%, (%rs1_Register_int%), %vs2%%vm%"
+"vsuxei8.v" = "vsux%nf%ei8.v %vs3%, (%rs1_Register_int%), %vs2%%vm%"
 
 [format_24-0.repr]
 default = "vss%nf%e16.v %vs3%, (%rs1_Register_int%), %rs2_Register_int%%vm%"
-vsse32_v = "vss%nf%e32.v %vs3%, (%rs1_Register_int%), %rs2_Register_int%%vm%"
-vsse64_v = "vss%nf%e64.v %vs3%, (%rs1_Register_int%), %rs2_Register_int%%vm%"
-vsse8_v = "vss%nf%e8.v %vs3%, (%rs1_Register_int%), %rs2_Register_int%%vm%"
+"vsse32.v" = "vss%nf%e32.v %vs3%, (%rs1_Register_int%), %rs2_Register_int%%vm%"
+"vsse64.v" = "vss%nf%e64.v %vs3%, (%rs1_Register_int%), %rs2_Register_int%%vm%"
+"vsse8.v" = "vss%nf%e8.v %vs3%, (%rs1_Register_int%), %rs2_Register_int%%vm%"
 
 [mappings.Mapping_vtypei]
 0x0 = "e8, m1, tu, mu"
@@ -1503,1455 +1503,1455 @@ vsse8_v = "vss%nf%e8.v %vs3%, (%rs1_Register_int%), %rs2_Register_int%%vm%"
 0xde = "e64, mf4, ta, ma"
 0xdf = "e64, mf2, ta, ma"
 
-[format_1-0.instructions.vaadd_vv]
+[format_1-0.instructions."vaadd.vv"]
 mask = 0xfc00707f
 match = 0x24002057
 
-[format_1-0.instructions.vaaddu_vv]
+[format_1-0.instructions."vaaddu.vv"]
 mask = 0xfc00707f
 match = 0x20002057
 
-[format_1-0.instructions.vadd_vv]
+[format_1-0.instructions."vadd.vv"]
 mask = 0xfc00707f
 match = 0x57
 
-[format_1-0.instructions.vand_vv]
+[format_1-0.instructions."vand.vv"]
 mask = 0xfc00707f
 match = 0x24000057
 
-[format_1-0.instructions.vasub_vv]
+[format_1-0.instructions."vasub.vv"]
 mask = 0xfc00707f
 match = 0x2c002057
 
-[format_1-0.instructions.vasubu_vv]
+[format_1-0.instructions."vasubu.vv"]
 mask = 0xfc00707f
 match = 0x28002057
 
-[format_1-0.instructions.vdiv_vv]
+[format_1-0.instructions."vdiv.vv"]
 mask = 0xfc00707f
 match = 0x84002057
 
-[format_1-0.instructions.vdivu_vv]
+[format_1-0.instructions."vdivu.vv"]
 mask = 0xfc00707f
 match = 0x80002057
 
-[format_1-0.instructions.vfadd_vv]
+[format_1-0.instructions."vfadd.vv"]
 mask = 0xfc00707f
 match = 0x1057
 
-[format_1-0.instructions.vfdiv_vv]
+[format_1-0.instructions."vfdiv.vv"]
 mask = 0xfc00707f
 match = 0x80001057
 
-[format_1-0.instructions.vfmacc_vv]
+[format_1-0.instructions."vfmacc.vv"]
 mask = 0xfc00707f
 match = 0xb0001057
 
-[format_1-0.instructions.vfmadd_vv]
+[format_1-0.instructions."vfmadd.vv"]
 mask = 0xfc00707f
 match = 0xa0001057
 
-[format_1-0.instructions.vfmax_vv]
+[format_1-0.instructions."vfmax.vv"]
 mask = 0xfc00707f
 match = 0x18001057
 
-[format_1-0.instructions.vfmin_vv]
+[format_1-0.instructions."vfmin.vv"]
 mask = 0xfc00707f
 match = 0x10001057
 
-[format_1-0.instructions.vfmsac_vv]
+[format_1-0.instructions."vfmsac.vv"]
 mask = 0xfc00707f
 match = 0xb8001057
 
-[format_1-0.instructions.vfmsub_vv]
+[format_1-0.instructions."vfmsub.vv"]
 mask = 0xfc00707f
 match = 0xa8001057
 
-[format_1-0.instructions.vfmul_vv]
+[format_1-0.instructions."vfmul.vv"]
 mask = 0xfc00707f
 match = 0x90001057
 
-[format_1-0.instructions.vfnmacc_vv]
+[format_1-0.instructions."vfnmacc.vv"]
 mask = 0xfc00707f
 match = 0xb4001057
 
-[format_1-0.instructions.vfnmadd_vv]
+[format_1-0.instructions."vfnmadd.vv"]
 mask = 0xfc00707f
 match = 0xa4001057
 
-[format_1-0.instructions.vfnmsac_vv]
+[format_1-0.instructions."vfnmsac.vv"]
 mask = 0xfc00707f
 match = 0xbc001057
 
-[format_1-0.instructions.vfnmsub_vv]
+[format_1-0.instructions."vfnmsub.vv"]
 mask = 0xfc00707f
 match = 0xac001057
 
-[format_1-0.instructions.vfredmax_vs]
+[format_1-0.instructions."vfredmax.vs"]
 mask = 0xfc00707f
 match = 0x1c001057
 
-[format_1-0.instructions.vfredmin_vs]
+[format_1-0.instructions."vfredmin.vs"]
 mask = 0xfc00707f
 match = 0x14001057
 
-[format_1-0.instructions.vfredosum_vs]
+[format_1-0.instructions."vfredosum.vs"]
 mask = 0xfc00707f
 match = 0xc001057
 
-[format_1-0.instructions.vfredusum_vs]
+[format_1-0.instructions."vfredusum.vs"]
 mask = 0xfc00707f
 match = 0x4001057
 
-[format_1-0.instructions.vfsgnj_vv]
+[format_1-0.instructions."vfsgnj.vv"]
 mask = 0xfc00707f
 match = 0x20001057
 
-[format_1-0.instructions.vfsgnjn_vv]
+[format_1-0.instructions."vfsgnjn.vv"]
 mask = 0xfc00707f
 match = 0x24001057
 
-[format_1-0.instructions.vfsgnjx_vv]
+[format_1-0.instructions."vfsgnjx.vv"]
 mask = 0xfc00707f
 match = 0x28001057
 
-[format_1-0.instructions.vfsub_vv]
+[format_1-0.instructions."vfsub.vv"]
 mask = 0xfc00707f
 match = 0x8001057
 
-[format_1-0.instructions.vfwadd_vv]
+[format_1-0.instructions."vfwadd.vv"]
 mask = 0xfc00707f
 match = 0xc0001057
 
-[format_1-0.instructions.vfwadd_wv]
+[format_1-0.instructions."vfwadd.wv"]
 mask = 0xfc00707f
 match = 0xd0001057
 
-[format_1-0.instructions.vfwmacc_vv]
+[format_1-0.instructions."vfwmacc.vv"]
 mask = 0xfc00707f
 match = 0xf0001057
 
-[format_1-0.instructions.vfwmsac_vv]
+[format_1-0.instructions."vfwmsac.vv"]
 mask = 0xfc00707f
 match = 0xf8001057
 
-[format_1-0.instructions.vfwmul_vv]
+[format_1-0.instructions."vfwmul.vv"]
 mask = 0xfc00707f
 match = 0xe0001057
 
-[format_1-0.instructions.vfwnmacc_vv]
+[format_1-0.instructions."vfwnmacc.vv"]
 mask = 0xfc00707f
 match = 0xf4001057
 
-[format_1-0.instructions.vfwnmsac_vv]
+[format_1-0.instructions."vfwnmsac.vv"]
 mask = 0xfc00707f
 match = 0xfc001057
 
-[format_1-0.instructions.vfwredosum_vs]
+[format_1-0.instructions."vfwredosum.vs"]
 mask = 0xfc00707f
 match = 0xcc001057
 
-[format_1-0.instructions.vfwredusum_vs]
+[format_1-0.instructions."vfwredusum.vs"]
 mask = 0xfc00707f
 match = 0xc4001057
 
-[format_1-0.instructions.vfwsub_vv]
+[format_1-0.instructions."vfwsub.vv"]
 mask = 0xfc00707f
 match = 0xc8001057
 
-[format_1-0.instructions.vfwsub_wv]
+[format_1-0.instructions."vfwsub.wv"]
 mask = 0xfc00707f
 match = 0xd8001057
 
-[format_1-0.instructions.vmacc_vv]
+[format_1-0.instructions."vmacc.vv"]
 mask = 0xfc00707f
 match = 0xb4002057
 
-[format_1-0.instructions.vmadd_vv]
+[format_1-0.instructions."vmadd.vv"]
 mask = 0xfc00707f
 match = 0xa4002057
 
-[format_1-0.instructions.vmax_vv]
+[format_1-0.instructions."vmax.vv"]
 mask = 0xfc00707f
 match = 0x1c000057
 
-[format_1-0.instructions.vmaxu_vv]
+[format_1-0.instructions."vmaxu.vv"]
 mask = 0xfc00707f
 match = 0x18000057
 
-[format_1-0.instructions.vmfeq_vv]
+[format_1-0.instructions."vmfeq.vv"]
 mask = 0xfc00707f
 match = 0x60001057
 
-[format_1-0.instructions.vmfle_vv]
+[format_1-0.instructions."vmfle.vv"]
 mask = 0xfc00707f
 match = 0x64001057
 
-[format_1-0.instructions.vmflt_vv]
+[format_1-0.instructions."vmflt.vv"]
 mask = 0xfc00707f
 match = 0x6c001057
 
-[format_1-0.instructions.vmfne_vv]
+[format_1-0.instructions."vmfne.vv"]
 mask = 0xfc00707f
 match = 0x70001057
 
-[format_1-0.instructions.vmin_vv]
+[format_1-0.instructions."vmin.vv"]
 mask = 0xfc00707f
 match = 0x14000057
 
-[format_1-0.instructions.vminu_vv]
+[format_1-0.instructions."vminu.vv"]
 mask = 0xfc00707f
 match = 0x10000057
 
-[format_1-0.instructions.vmseq_vv]
+[format_1-0.instructions."vmseq.vv"]
 mask = 0xfc00707f
 match = 0x60000057
 
-[format_1-0.instructions.vmsle_vv]
+[format_1-0.instructions."vmsle.vv"]
 mask = 0xfc00707f
 match = 0x74000057
 
-[format_1-0.instructions.vmsleu_vv]
+[format_1-0.instructions."vmsleu.vv"]
 mask = 0xfc00707f
 match = 0x70000057
 
-[format_1-0.instructions.vmslt_vv]
+[format_1-0.instructions."vmslt.vv"]
 mask = 0xfc00707f
 match = 0x6c000057
 
-[format_1-0.instructions.vmsltu_vv]
+[format_1-0.instructions."vmsltu.vv"]
 mask = 0xfc00707f
 match = 0x68000057
 
-[format_1-0.instructions.vmsne_vv]
+[format_1-0.instructions."vmsne.vv"]
 mask = 0xfc00707f
 match = 0x64000057
 
-[format_1-0.instructions.vmul_vv]
+[format_1-0.instructions."vmul.vv"]
 mask = 0xfc00707f
 match = 0x94002057
 
-[format_1-0.instructions.vmulh_vv]
+[format_1-0.instructions."vmulh.vv"]
 mask = 0xfc00707f
 match = 0x9c002057
 
-[format_1-0.instructions.vmulhsu_vv]
+[format_1-0.instructions."vmulhsu.vv"]
 mask = 0xfc00707f
 match = 0x98002057
 
-[format_1-0.instructions.vmulhu_vv]
+[format_1-0.instructions."vmulhu.vv"]
 mask = 0xfc00707f
 match = 0x90002057
 
-[format_1-0.instructions.vnclip_wv]
+[format_1-0.instructions."vnclip.wv"]
 mask = 0xfc00707f
 match = 0xbc000057
 
-[format_1-0.instructions.vnclipu_wv]
+[format_1-0.instructions."vnclipu.wv"]
 mask = 0xfc00707f
 match = 0xb8000057
 
-[format_1-0.instructions.vnmsac_vv]
+[format_1-0.instructions."vnmsac.vv"]
 mask = 0xfc00707f
 match = 0xbc002057
 
-[format_1-0.instructions.vnmsub_vv]
+[format_1-0.instructions."vnmsub.vv"]
 mask = 0xfc00707f
 match = 0xac002057
 
-[format_1-0.instructions.vnsra_wv]
+[format_1-0.instructions."vnsra.wv"]
 mask = 0xfc00707f
 match = 0xb4000057
 
-[format_1-0.instructions.vnsrl_wv]
+[format_1-0.instructions."vnsrl.wv"]
 mask = 0xfc00707f
 match = 0xb0000057
 
-[format_1-0.instructions.vor_vv]
+[format_1-0.instructions."vor.vv"]
 mask = 0xfc00707f
 match = 0x28000057
 
-[format_1-0.instructions.vredand_vs]
+[format_1-0.instructions."vredand.vs"]
 mask = 0xfc00707f
 match = 0x4002057
 
-[format_1-0.instructions.vredmax_vs]
+[format_1-0.instructions."vredmax.vs"]
 mask = 0xfc00707f
 match = 0x1c002057
 
-[format_1-0.instructions.vredmaxu_vs]
+[format_1-0.instructions."vredmaxu.vs"]
 mask = 0xfc00707f
 match = 0x18002057
 
-[format_1-0.instructions.vredmin_vs]
+[format_1-0.instructions."vredmin.vs"]
 mask = 0xfc00707f
 match = 0x14002057
 
-[format_1-0.instructions.vredminu_vs]
+[format_1-0.instructions."vredminu.vs"]
 mask = 0xfc00707f
 match = 0x10002057
 
-[format_1-0.instructions.vredor_vs]
+[format_1-0.instructions."vredor.vs"]
 mask = 0xfc00707f
 match = 0x8002057
 
-[format_1-0.instructions.vredsum_vs]
+[format_1-0.instructions."vredsum.vs"]
 mask = 0xfc00707f
 match = 0x2057
 
-[format_1-0.instructions.vredxor_vs]
+[format_1-0.instructions."vredxor.vs"]
 mask = 0xfc00707f
 match = 0xc002057
 
-[format_1-0.instructions.vrem_vv]
+[format_1-0.instructions."vrem.vv"]
 mask = 0xfc00707f
 match = 0x8c002057
 
-[format_1-0.instructions.vremu_vv]
+[format_1-0.instructions."vremu.vv"]
 mask = 0xfc00707f
 match = 0x88002057
 
-[format_1-0.instructions.vrgather_vv]
+[format_1-0.instructions."vrgather.vv"]
 mask = 0xfc00707f
 match = 0x30000057
 
-[format_1-0.instructions.vrgatherei16_vv]
+[format_1-0.instructions."vrgatherei16.vv"]
 mask = 0xfc00707f
 match = 0x38000057
 
-[format_1-0.instructions.vsadd_vv]
+[format_1-0.instructions."vsadd.vv"]
 mask = 0xfc00707f
 match = 0x84000057
 
-[format_1-0.instructions.vsaddu_vv]
+[format_1-0.instructions."vsaddu.vv"]
 mask = 0xfc00707f
 match = 0x80000057
 
-[format_1-0.instructions.vsll_vv]
+[format_1-0.instructions."vsll.vv"]
 mask = 0xfc00707f
 match = 0x94000057
 
-[format_1-0.instructions.vsmul_vv]
+[format_1-0.instructions."vsmul.vv"]
 mask = 0xfc00707f
 match = 0x9c000057
 
-[format_1-0.instructions.vsra_vv]
+[format_1-0.instructions."vsra.vv"]
 mask = 0xfc00707f
 match = 0xa4000057
 
-[format_1-0.instructions.vsrl_vv]
+[format_1-0.instructions."vsrl.vv"]
 mask = 0xfc00707f
 match = 0xa0000057
 
-[format_1-0.instructions.vssra_vv]
+[format_1-0.instructions."vssra.vv"]
 mask = 0xfc00707f
 match = 0xac000057
 
-[format_1-0.instructions.vssrl_vv]
+[format_1-0.instructions."vssrl.vv"]
 mask = 0xfc00707f
 match = 0xa8000057
 
-[format_1-0.instructions.vssub_vv]
+[format_1-0.instructions."vssub.vv"]
 mask = 0xfc00707f
 match = 0x8c000057
 
-[format_1-0.instructions.vssubu_vv]
+[format_1-0.instructions."vssubu.vv"]
 mask = 0xfc00707f
 match = 0x88000057
 
-[format_1-0.instructions.vsub_vv]
+[format_1-0.instructions."vsub.vv"]
 mask = 0xfc00707f
 match = 0x8000057
 
-[format_1-0.instructions.vwadd_vv]
+[format_1-0.instructions."vwadd.vv"]
 mask = 0xfc00707f
 match = 0xc4002057
 
-[format_1-0.instructions.vwadd_wv]
+[format_1-0.instructions."vwadd.wv"]
 mask = 0xfc00707f
 match = 0xd4002057
 
-[format_1-0.instructions.vwaddu_vv]
+[format_1-0.instructions."vwaddu.vv"]
 mask = 0xfc00707f
 match = 0xc0002057
 
-[format_1-0.instructions.vwaddu_wv]
+[format_1-0.instructions."vwaddu.wv"]
 mask = 0xfc00707f
 match = 0xd0002057
 
-[format_1-0.instructions.vwmacc_vv]
+[format_1-0.instructions."vwmacc.vv"]
 mask = 0xfc00707f
 match = 0xf4002057
 
-[format_1-0.instructions.vwmaccsu_vv]
+[format_1-0.instructions."vwmaccsu.vv"]
 mask = 0xfc00707f
 match = 0xfc002057
 
-[format_1-0.instructions.vwmaccu_vv]
+[format_1-0.instructions."vwmaccu.vv"]
 mask = 0xfc00707f
 match = 0xf0002057
 
-[format_1-0.instructions.vwmul_vv]
+[format_1-0.instructions."vwmul.vv"]
 mask = 0xfc00707f
 match = 0xec002057
 
-[format_1-0.instructions.vwmulsu_vv]
+[format_1-0.instructions."vwmulsu.vv"]
 mask = 0xfc00707f
 match = 0xe8002057
 
-[format_1-0.instructions.vwmulu_vv]
+[format_1-0.instructions."vwmulu.vv"]
 mask = 0xfc00707f
 match = 0xe0002057
 
-[format_1-0.instructions.vwredsum_vs]
+[format_1-0.instructions."vwredsum.vs"]
 mask = 0xfc00707f
 match = 0xc4000057
 
-[format_1-0.instructions.vwredsumu_vs]
+[format_1-0.instructions."vwredsumu.vs"]
 mask = 0xfc00707f
 match = 0xc0000057
 
-[format_1-0.instructions.vwsub_vv]
+[format_1-0.instructions."vwsub.vv"]
 mask = 0xfc00707f
 match = 0xcc002057
 
-[format_1-0.instructions.vwsub_wv]
+[format_1-0.instructions."vwsub.wv"]
 mask = 0xfc00707f
 match = 0xdc002057
 
-[format_1-0.instructions.vwsubu_vv]
+[format_1-0.instructions."vwsubu.vv"]
 mask = 0xfc00707f
 match = 0xc8002057
 
-[format_1-0.instructions.vwsubu_wv]
+[format_1-0.instructions."vwsubu.wv"]
 mask = 0xfc00707f
 match = 0xd8002057
 
-[format_1-0.instructions.vxor_vv]
+[format_1-0.instructions."vxor.vv"]
 mask = 0xfc00707f
 match = 0x2c000057
 
-[format_2-0.instructions.vaadd_vx]
+[format_2-0.instructions."vaadd.vx"]
 mask = 0xfc00707f
 match = 0x24006057
 
-[format_2-0.instructions.vaaddu_vx]
+[format_2-0.instructions."vaaddu.vx"]
 mask = 0xfc00707f
 match = 0x20006057
 
-[format_2-0.instructions.vadd_vx]
+[format_2-0.instructions."vadd.vx"]
 mask = 0xfc00707f
 match = 0x4057
 
-[format_2-0.instructions.vand_vx]
+[format_2-0.instructions."vand.vx"]
 mask = 0xfc00707f
 match = 0x24004057
 
-[format_2-0.instructions.vasub_vx]
+[format_2-0.instructions."vasub.vx"]
 mask = 0xfc00707f
 match = 0x2c006057
 
-[format_2-0.instructions.vasubu_vx]
+[format_2-0.instructions."vasubu.vx"]
 mask = 0xfc00707f
 match = 0x28006057
 
-[format_2-0.instructions.vdiv_vx]
+[format_2-0.instructions."vdiv.vx"]
 mask = 0xfc00707f
 match = 0x84006057
 
-[format_2-0.instructions.vdivu_vx]
+[format_2-0.instructions."vdivu.vx"]
 mask = 0xfc00707f
 match = 0x80006057
 
-[format_2-0.instructions.vmacc_vx]
+[format_2-0.instructions."vmacc.vx"]
 mask = 0xfc00707f
 match = 0xb4006057
 
-[format_2-0.instructions.vmadd_vx]
+[format_2-0.instructions."vmadd.vx"]
 mask = 0xfc00707f
 match = 0xa4006057
 
-[format_2-0.instructions.vmax_vx]
+[format_2-0.instructions."vmax.vx"]
 mask = 0xfc00707f
 match = 0x1c004057
 
-[format_2-0.instructions.vmaxu_vx]
+[format_2-0.instructions."vmaxu.vx"]
 mask = 0xfc00707f
 match = 0x18004057
 
-[format_2-0.instructions.vmin_vx]
+[format_2-0.instructions."vmin.vx"]
 mask = 0xfc00707f
 match = 0x14004057
 
-[format_2-0.instructions.vminu_vx]
+[format_2-0.instructions."vminu.vx"]
 mask = 0xfc00707f
 match = 0x10004057
 
-[format_2-0.instructions.vmseq_vx]
+[format_2-0.instructions."vmseq.vx"]
 mask = 0xfc00707f
 match = 0x60004057
 
-[format_2-0.instructions.vmsgt_vx]
+[format_2-0.instructions."vmsgt.vx"]
 mask = 0xfc00707f
 match = 0x7c004057
 
-[format_2-0.instructions.vmsgtu_vx]
+[format_2-0.instructions."vmsgtu.vx"]
 mask = 0xfc00707f
 match = 0x78004057
 
-[format_2-0.instructions.vmsle_vx]
+[format_2-0.instructions."vmsle.vx"]
 mask = 0xfc00707f
 match = 0x74004057
 
-[format_2-0.instructions.vmsleu_vx]
+[format_2-0.instructions."vmsleu.vx"]
 mask = 0xfc00707f
 match = 0x70004057
 
-[format_2-0.instructions.vmslt_vx]
+[format_2-0.instructions."vmslt.vx"]
 mask = 0xfc00707f
 match = 0x6c004057
 
-[format_2-0.instructions.vmsltu_vx]
+[format_2-0.instructions."vmsltu.vx"]
 mask = 0xfc00707f
 match = 0x68004057
 
-[format_2-0.instructions.vmsne_vx]
+[format_2-0.instructions."vmsne.vx"]
 mask = 0xfc00707f
 match = 0x64004057
 
-[format_2-0.instructions.vmul_vx]
+[format_2-0.instructions."vmul.vx"]
 mask = 0xfc00707f
 match = 0x94006057
 
-[format_2-0.instructions.vmulh_vx]
+[format_2-0.instructions."vmulh.vx"]
 mask = 0xfc00707f
 match = 0x9c006057
 
-[format_2-0.instructions.vmulhsu_vx]
+[format_2-0.instructions."vmulhsu.vx"]
 mask = 0xfc00707f
 match = 0x98006057
 
-[format_2-0.instructions.vmulhu_vx]
+[format_2-0.instructions."vmulhu.vx"]
 mask = 0xfc00707f
 match = 0x90006057
 
-[format_2-0.instructions.vnclip_wx]
+[format_2-0.instructions."vnclip.wx"]
 mask = 0xfc00707f
 match = 0xbc004057
 
-[format_2-0.instructions.vnclipu_wx]
+[format_2-0.instructions."vnclipu.wx"]
 mask = 0xfc00707f
 match = 0xb8004057
 
-[format_2-0.instructions.vnmsac_vx]
+[format_2-0.instructions."vnmsac.vx"]
 mask = 0xfc00707f
 match = 0xbc006057
 
-[format_2-0.instructions.vnmsub_vx]
+[format_2-0.instructions."vnmsub.vx"]
 mask = 0xfc00707f
 match = 0xac006057
 
-[format_2-0.instructions.vnsra_wx]
+[format_2-0.instructions."vnsra.wx"]
 mask = 0xfc00707f
 match = 0xb4004057
 
-[format_2-0.instructions.vnsrl_wx]
+[format_2-0.instructions."vnsrl.wx"]
 mask = 0xfc00707f
 match = 0xb0004057
 
-[format_2-0.instructions.vor_vx]
+[format_2-0.instructions."vor.vx"]
 mask = 0xfc00707f
 match = 0x28004057
 
-[format_2-0.instructions.vrem_vx]
+[format_2-0.instructions."vrem.vx"]
 mask = 0xfc00707f
 match = 0x8c006057
 
-[format_2-0.instructions.vremu_vx]
+[format_2-0.instructions."vremu.vx"]
 mask = 0xfc00707f
 match = 0x88006057
 
-[format_2-0.instructions.vrgather_vx]
+[format_2-0.instructions."vrgather.vx"]
 mask = 0xfc00707f
 match = 0x30004057
 
-[format_2-0.instructions.vrsub_vx]
+[format_2-0.instructions."vrsub.vx"]
 mask = 0xfc00707f
 match = 0xc004057
 
-[format_2-0.instructions.vsadd_vx]
+[format_2-0.instructions."vsadd.vx"]
 mask = 0xfc00707f
 match = 0x84004057
 
-[format_2-0.instructions.vsaddu_vx]
+[format_2-0.instructions."vsaddu.vx"]
 mask = 0xfc00707f
 match = 0x80004057
 
-[format_2-0.instructions.vslide1down_vx]
+[format_2-0.instructions."vslide1down.vx"]
 mask = 0xfc00707f
 match = 0x3c006057
 
-[format_2-0.instructions.vslide1up_vx]
+[format_2-0.instructions."vslide1up.vx"]
 mask = 0xfc00707f
 match = 0x38006057
 
-[format_2-0.instructions.vslidedown_vx]
+[format_2-0.instructions."vslidedown.vx"]
 mask = 0xfc00707f
 match = 0x3c004057
 
-[format_2-0.instructions.vslideup_vx]
+[format_2-0.instructions."vslideup.vx"]
 mask = 0xfc00707f
 match = 0x38004057
 
-[format_2-0.instructions.vsll_vx]
+[format_2-0.instructions."vsll.vx"]
 mask = 0xfc00707f
 match = 0x94004057
 
-[format_2-0.instructions.vsmul_vx]
+[format_2-0.instructions."vsmul.vx"]
 mask = 0xfc00707f
 match = 0x9c004057
 
-[format_2-0.instructions.vsra_vx]
+[format_2-0.instructions."vsra.vx"]
 mask = 0xfc00707f
 match = 0xa4004057
 
-[format_2-0.instructions.vsrl_vx]
+[format_2-0.instructions."vsrl.vx"]
 mask = 0xfc00707f
 match = 0xa0004057
 
-[format_2-0.instructions.vssra_vx]
+[format_2-0.instructions."vssra.vx"]
 mask = 0xfc00707f
 match = 0xac004057
 
-[format_2-0.instructions.vssrl_vx]
+[format_2-0.instructions."vssrl.vx"]
 mask = 0xfc00707f
 match = 0xa8004057
 
-[format_2-0.instructions.vssub_vx]
+[format_2-0.instructions."vssub.vx"]
 mask = 0xfc00707f
 match = 0x8c004057
 
-[format_2-0.instructions.vssubu_vx]
+[format_2-0.instructions."vssubu.vx"]
 mask = 0xfc00707f
 match = 0x88004057
 
-[format_2-0.instructions.vsub_vx]
+[format_2-0.instructions."vsub.vx"]
 mask = 0xfc00707f
 match = 0x8004057
 
-[format_2-0.instructions.vwadd_vx]
+[format_2-0.instructions."vwadd.vx"]
 mask = 0xfc00707f
 match = 0xc4006057
 
-[format_2-0.instructions.vwadd_wx]
+[format_2-0.instructions."vwadd.wx"]
 mask = 0xfc00707f
 match = 0xd4006057
 
-[format_2-0.instructions.vwaddu_vx]
+[format_2-0.instructions."vwaddu.vx"]
 mask = 0xfc00707f
 match = 0xc0006057
 
-[format_2-0.instructions.vwaddu_wx]
+[format_2-0.instructions."vwaddu.wx"]
 mask = 0xfc00707f
 match = 0xd0006057
 
-[format_2-0.instructions.vwmacc_vx]
+[format_2-0.instructions."vwmacc.vx"]
 mask = 0xfc00707f
 match = 0xf4006057
 
-[format_2-0.instructions.vwmaccsu_vx]
+[format_2-0.instructions."vwmaccsu.vx"]
 mask = 0xfc00707f
 match = 0xfc006057
 
-[format_2-0.instructions.vwmaccu_vx]
+[format_2-0.instructions."vwmaccu.vx"]
 mask = 0xfc00707f
 match = 0xf0006057
 
-[format_2-0.instructions.vwmaccus_vx]
+[format_2-0.instructions."vwmaccus.vx"]
 mask = 0xfc00707f
 match = 0xf8006057
 
-[format_2-0.instructions.vwmul_vx]
+[format_2-0.instructions."vwmul.vx"]
 mask = 0xfc00707f
 match = 0xec006057
 
-[format_2-0.instructions.vwmulsu_vx]
+[format_2-0.instructions."vwmulsu.vx"]
 mask = 0xfc00707f
 match = 0xe8006057
 
-[format_2-0.instructions.vwmulu_vx]
+[format_2-0.instructions."vwmulu.vx"]
 mask = 0xfc00707f
 match = 0xe0006057
 
-[format_2-0.instructions.vwsub_vx]
+[format_2-0.instructions."vwsub.vx"]
 mask = 0xfc00707f
 match = 0xcc006057
 
-[format_2-0.instructions.vwsub_wx]
+[format_2-0.instructions."vwsub.wx"]
 mask = 0xfc00707f
 match = 0xdc006057
 
-[format_2-0.instructions.vwsubu_vx]
+[format_2-0.instructions."vwsubu.vx"]
 mask = 0xfc00707f
 match = 0xc8006057
 
-[format_2-0.instructions.vwsubu_wx]
+[format_2-0.instructions."vwsubu.wx"]
 mask = 0xfc00707f
 match = 0xd8006057
 
-[format_2-0.instructions.vxor_vx]
+[format_2-0.instructions."vxor.vx"]
 mask = 0xfc00707f
 match = 0x2c004057
 
-[format_2-1.instructions.vfadd_vf]
+[format_2-1.instructions."vfadd.vf"]
 mask = 0xfc00707f
 match = 0x5057
 
-[format_2-1.instructions.vfdiv_vf]
+[format_2-1.instructions."vfdiv.vf"]
 mask = 0xfc00707f
 match = 0x80005057
 
-[format_2-1.instructions.vfmacc_vf]
+[format_2-1.instructions."vfmacc.vf"]
 mask = 0xfc00707f
 match = 0xb0005057
 
-[format_2-1.instructions.vfmadd_vf]
+[format_2-1.instructions."vfmadd.vf"]
 mask = 0xfc00707f
 match = 0xa0005057
 
-[format_2-1.instructions.vfmax_vf]
+[format_2-1.instructions."vfmax.vf"]
 mask = 0xfc00707f
 match = 0x18005057
 
-[format_2-1.instructions.vfmin_vf]
+[format_2-1.instructions."vfmin.vf"]
 mask = 0xfc00707f
 match = 0x10005057
 
-[format_2-1.instructions.vfmsac_vf]
+[format_2-1.instructions."vfmsac.vf"]
 mask = 0xfc00707f
 match = 0xb8005057
 
-[format_2-1.instructions.vfmsub_vf]
+[format_2-1.instructions."vfmsub.vf"]
 mask = 0xfc00707f
 match = 0xa8005057
 
-[format_2-1.instructions.vfmul_vf]
+[format_2-1.instructions."vfmul.vf"]
 mask = 0xfc00707f
 match = 0x90005057
 
-[format_2-1.instructions.vfnmacc_vf]
+[format_2-1.instructions."vfnmacc.vf"]
 mask = 0xfc00707f
 match = 0xb4005057
 
-[format_2-1.instructions.vfnmadd_vf]
+[format_2-1.instructions."vfnmadd.vf"]
 mask = 0xfc00707f
 match = 0xa4005057
 
-[format_2-1.instructions.vfnmsac_vf]
+[format_2-1.instructions."vfnmsac.vf"]
 mask = 0xfc00707f
 match = 0xbc005057
 
-[format_2-1.instructions.vfnmsub_vf]
+[format_2-1.instructions."vfnmsub.vf"]
 mask = 0xfc00707f
 match = 0xac005057
 
-[format_2-1.instructions.vfrdiv_vf]
+[format_2-1.instructions."vfrdiv.vf"]
 mask = 0xfc00707f
 match = 0x84005057
 
-[format_2-1.instructions.vfrsub_vf]
+[format_2-1.instructions."vfrsub.vf"]
 mask = 0xfc00707f
 match = 0x9c005057
 
-[format_2-1.instructions.vfsgnj_vf]
+[format_2-1.instructions."vfsgnj.vf"]
 mask = 0xfc00707f
 match = 0x20005057
 
-[format_2-1.instructions.vfsgnjn_vf]
+[format_2-1.instructions."vfsgnjn.vf"]
 mask = 0xfc00707f
 match = 0x24005057
 
-[format_2-1.instructions.vfsgnjx_vf]
+[format_2-1.instructions."vfsgnjx.vf"]
 mask = 0xfc00707f
 match = 0x28005057
 
-[format_2-1.instructions.vfslide1down_vf]
+[format_2-1.instructions."vfslide1down.vf"]
 mask = 0xfc00707f
 match = 0x3c005057
 
-[format_2-1.instructions.vfslide1up_vf]
+[format_2-1.instructions."vfslide1up.vf"]
 mask = 0xfc00707f
 match = 0x38005057
 
-[format_2-1.instructions.vfsub_vf]
+[format_2-1.instructions."vfsub.vf"]
 mask = 0xfc00707f
 match = 0x8005057
 
-[format_2-1.instructions.vfwadd_vf]
+[format_2-1.instructions."vfwadd.vf"]
 mask = 0xfc00707f
 match = 0xc0005057
 
-[format_2-1.instructions.vfwadd_wf]
+[format_2-1.instructions."vfwadd.wf"]
 mask = 0xfc00707f
 match = 0xd0005057
 
-[format_2-1.instructions.vfwmacc_vf]
+[format_2-1.instructions."vfwmacc.vf"]
 mask = 0xfc00707f
 match = 0xf0005057
 
-[format_2-1.instructions.vfwmsac_vf]
+[format_2-1.instructions."vfwmsac.vf"]
 mask = 0xfc00707f
 match = 0xf8005057
 
-[format_2-1.instructions.vfwmul_vf]
+[format_2-1.instructions."vfwmul.vf"]
 mask = 0xfc00707f
 match = 0xe0005057
 
-[format_2-1.instructions.vfwnmacc_vf]
+[format_2-1.instructions."vfwnmacc.vf"]
 mask = 0xfc00707f
 match = 0xf4005057
 
-[format_2-1.instructions.vfwnmsac_vf]
+[format_2-1.instructions."vfwnmsac.vf"]
 mask = 0xfc00707f
 match = 0xfc005057
 
-[format_2-1.instructions.vfwsub_vf]
+[format_2-1.instructions."vfwsub.vf"]
 mask = 0xfc00707f
 match = 0xc8005057
 
-[format_2-1.instructions.vfwsub_wf]
+[format_2-1.instructions."vfwsub.wf"]
 mask = 0xfc00707f
 match = 0xd8005057
 
-[format_2-1.instructions.vmfeq_vf]
+[format_2-1.instructions."vmfeq.vf"]
 mask = 0xfc00707f
 match = 0x60005057
 
-[format_2-1.instructions.vmfge_vf]
+[format_2-1.instructions."vmfge.vf"]
 mask = 0xfc00707f
 match = 0x7c005057
 
-[format_2-1.instructions.vmfgt_vf]
+[format_2-1.instructions."vmfgt.vf"]
 mask = 0xfc00707f
 match = 0x74005057
 
-[format_2-1.instructions.vmfle_vf]
+[format_2-1.instructions."vmfle.vf"]
 mask = 0xfc00707f
 match = 0x64005057
 
-[format_2-1.instructions.vmflt_vf]
+[format_2-1.instructions."vmflt.vf"]
 mask = 0xfc00707f
 match = 0x6c005057
 
-[format_2-1.instructions.vmfne_vf]
+[format_2-1.instructions."vmfne.vf"]
 mask = 0xfc00707f
 match = 0x70005057
 
-[format_3-0.instructions.vadc_vim]
+[format_3-0.instructions."vadc.vim"]
 mask = 0xfe00707f
 match = 0x40003057
 
-[format_3-0.instructions.vmadc_vi]
+[format_3-0.instructions."vmadc.vi"]
 mask = 0xfe00707f
 match = 0x46003057
 
-[format_3-0.instructions.vmadc_vim]
+[format_3-0.instructions."vmadc.vim"]
 mask = 0xfe00707f
 match = 0x44003057
 
-[format_3-0.instructions.vmerge_vim]
+[format_3-0.instructions."vmerge.vim"]
 mask = 0xfe00707f
 match = 0x5c003057
 
-[format_4-0.instructions.vadc_vvm]
+[format_4-0.instructions."vadc.vvm"]
 mask = 0xfe00707f
 match = 0x40000057
 
-[format_4-0.instructions.vcompress_vm]
+[format_4-0.instructions."vcompress.vm"]
 mask = 0xfe00707f
 match = 0x5e002057
 
-[format_4-0.instructions.vmadc_vv]
+[format_4-0.instructions."vmadc.vv"]
 mask = 0xfe00707f
 match = 0x46000057
 
-[format_4-0.instructions.vmadc_vvm]
+[format_4-0.instructions."vmadc.vvm"]
 mask = 0xfe00707f
 match = 0x44000057
 
-[format_4-0.instructions.vmand_mm]
+[format_4-0.instructions."vmand.mm"]
 mask = 0xfe00707f
 match = 0x66002057
 
-[format_4-0.instructions.vmandn_mm]
+[format_4-0.instructions."vmandn.mm"]
 mask = 0xfe00707f
 match = 0x62002057
 
-[format_4-0.instructions.vmerge_vvm]
+[format_4-0.instructions."vmerge.vvm"]
 mask = 0xfe00707f
 match = 0x5c000057
 
-[format_4-0.instructions.vmnand_mm]
+[format_4-0.instructions."vmnand.mm"]
 mask = 0xfe00707f
 match = 0x76002057
 
-[format_4-0.instructions.vmnor_mm]
+[format_4-0.instructions."vmnor.mm"]
 mask = 0xfe00707f
 match = 0x7a002057
 
-[format_4-0.instructions.vmor_mm]
+[format_4-0.instructions."vmor.mm"]
 mask = 0xfe00707f
 match = 0x6a002057
 
-[format_4-0.instructions.vmorn_mm]
+[format_4-0.instructions."vmorn.mm"]
 mask = 0xfe00707f
 match = 0x72002057
 
-[format_4-0.instructions.vmsbc_vv]
+[format_4-0.instructions."vmsbc.vv"]
 mask = 0xfe00707f
 match = 0x4e000057
 
-[format_4-0.instructions.vmsbc_vvm]
+[format_4-0.instructions."vmsbc.vvm"]
 mask = 0xfe00707f
 match = 0x4c000057
 
-[format_4-0.instructions.vmxnor_mm]
+[format_4-0.instructions."vmxnor.mm"]
 mask = 0xfe00707f
 match = 0x7e002057
 
-[format_4-0.instructions.vmxor_mm]
+[format_4-0.instructions."vmxor.mm"]
 mask = 0xfe00707f
 match = 0x6e002057
 
-[format_4-0.instructions.vsbc_vvm]
+[format_4-0.instructions."vsbc.vvm"]
 mask = 0xfe00707f
 match = 0x48000057
 
-[format_5-0.instructions.vadc_vxm]
+[format_5-0.instructions."vadc.vxm"]
 mask = 0xfe00707f
 match = 0x40004057
 
-[format_5-0.instructions.vmadc_vx]
+[format_5-0.instructions."vmadc.vx"]
 mask = 0xfe00707f
 match = 0x46004057
 
-[format_5-0.instructions.vmadc_vxm]
+[format_5-0.instructions."vmadc.vxm"]
 mask = 0xfe00707f
 match = 0x44004057
 
-[format_5-0.instructions.vmerge_vxm]
+[format_5-0.instructions."vmerge.vxm"]
 mask = 0xfe00707f
 match = 0x5c004057
 
-[format_5-0.instructions.vmsbc_vx]
+[format_5-0.instructions."vmsbc.vx"]
 mask = 0xfe00707f
 match = 0x4e004057
 
-[format_5-0.instructions.vmsbc_vxm]
+[format_5-0.instructions."vmsbc.vxm"]
 mask = 0xfe00707f
 match = 0x4c004057
 
-[format_5-0.instructions.vsbc_vxm]
+[format_5-0.instructions."vsbc.vxm"]
 mask = 0xfe00707f
 match = 0x48004057
 
-[format_5-1.instructions.vfmerge_vfm]
+[format_5-1.instructions."vfmerge.vfm"]
 mask = 0xfe00707f
 match = 0x5c005057
 
-[format_6-0.instructions.vadd_vi]
+[format_6-0.instructions."vadd.vi"]
 mask = 0xfc00707f
 match = 0x3057
 
-[format_6-0.instructions.vand_vi]
+[format_6-0.instructions."vand.vi"]
 mask = 0xfc00707f
 match = 0x24003057
 
-[format_6-0.instructions.vmseq_vi]
+[format_6-0.instructions."vmseq.vi"]
 mask = 0xfc00707f
 match = 0x60003057
 
-[format_6-0.instructions.vmsgt_vi]
+[format_6-0.instructions."vmsgt.vi"]
 mask = 0xfc00707f
 match = 0x7c003057
 
-[format_6-0.instructions.vmsgtu_vi]
+[format_6-0.instructions."vmsgtu.vi"]
 mask = 0xfc00707f
 match = 0x78003057
 
-[format_6-0.instructions.vmsle_vi]
+[format_6-0.instructions."vmsle.vi"]
 mask = 0xfc00707f
 match = 0x74003057
 
-[format_6-0.instructions.vmsleu_vi]
+[format_6-0.instructions."vmsleu.vi"]
 mask = 0xfc00707f
 match = 0x70003057
 
-[format_6-0.instructions.vmsne_vi]
+[format_6-0.instructions."vmsne.vi"]
 mask = 0xfc00707f
 match = 0x64003057
 
-[format_6-0.instructions.vnclip_wi]
+[format_6-0.instructions."vnclip.wi"]
 mask = 0xfc00707f
 match = 0xbc003057
 unsigned = true
 
-[format_6-0.instructions.vnclipu_wi]
+[format_6-0.instructions."vnclipu.wi"]
 mask = 0xfc00707f
 match = 0xb8003057
 unsigned = true
 
-[format_6-0.instructions.vnsra_wi]
+[format_6-0.instructions."vnsra.wi"]
 mask = 0xfc00707f
 match = 0xb4003057
 unsigned = true
 
-[format_6-0.instructions.vnsrl_wi]
+[format_6-0.instructions."vnsrl.wi"]
 mask = 0xfc00707f
 match = 0xb0003057
 unsigned = true
 
-[format_6-0.instructions.vor_vi]
+[format_6-0.instructions."vor.vi"]
 mask = 0xfc00707f
 match = 0x28003057
 
-[format_6-0.instructions.vrgather_vi]
+[format_6-0.instructions."vrgather.vi"]
 mask = 0xfc00707f
 match = 0x30003057
 unsigned = true
 
-[format_6-0.instructions.vrsub_vi]
+[format_6-0.instructions."vrsub.vi"]
 mask = 0xfc00707f
 match = 0xc003057
 
-[format_6-0.instructions.vsadd_vi]
+[format_6-0.instructions."vsadd.vi"]
 mask = 0xfc00707f
 match = 0x84003057
 
-[format_6-0.instructions.vsaddu_vi]
+[format_6-0.instructions."vsaddu.vi"]
 mask = 0xfc00707f
 match = 0x80003057
 
-[format_6-0.instructions.vslidedown_vi]
+[format_6-0.instructions."vslidedown.vi"]
 mask = 0xfc00707f
 match = 0x3c003057
 unsigned = true
 
-[format_6-0.instructions.vslideup_vi]
+[format_6-0.instructions."vslideup.vi"]
 mask = 0xfc00707f
 match = 0x38003057
 unsigned = true
 
-[format_6-0.instructions.vsll_vi]
+[format_6-0.instructions."vsll.vi"]
 mask = 0xfc00707f
 match = 0x94003057
 unsigned = true
 
-[format_6-0.instructions.vsra_vi]
+[format_6-0.instructions."vsra.vi"]
 mask = 0xfc00707f
 match = 0xa4003057
 unsigned = true
 
-[format_6-0.instructions.vsrl_vi]
+[format_6-0.instructions."vsrl.vi"]
 mask = 0xfc00707f
 match = 0xa0003057
 unsigned = true
 
-[format_6-0.instructions.vssra_vi]
+[format_6-0.instructions."vssra.vi"]
 mask = 0xfc00707f
 match = 0xac003057
 unsigned = true
 
-[format_6-0.instructions.vssrl_vi]
+[format_6-0.instructions."vssrl.vi"]
 mask = 0xfc00707f
 match = 0xa8003057
 unsigned = true
 
-[format_6-0.instructions.vxor_vi]
+[format_6-0.instructions."vxor.vi"]
 mask = 0xfc00707f
 match = 0x2c003057
 
-[format_7-0.instructions.vcpop_m]
+[format_7-0.instructions."vcpop.m"]
 mask = 0xfc0ff07f
 match = 0x40082057
 
-[format_7-0.instructions.vfirst_m]
+[format_7-0.instructions."vfirst.m"]
 mask = 0xfc0ff07f
 match = 0x4008a057
 
-[format_8-0.instructions.vfclass_v]
+[format_8-0.instructions."vfclass.v"]
 mask = 0xfc0ff07f
 match = 0x4c081057
 
-[format_8-0.instructions.vfcvt_f_x_v]
+[format_8-0.instructions."vfcvt.f.x.v"]
 mask = 0xfc0ff07f
 match = 0x48019057
 
-[format_8-0.instructions.vfcvt_f_xu_v]
+[format_8-0.instructions."vfcvt.f.xu.v"]
 mask = 0xfc0ff07f
 match = 0x48011057
 
-[format_8-0.instructions.vfcvt_rtz_x_f_v]
+[format_8-0.instructions."vfcvt.rtz.x.f.v"]
 mask = 0xfc0ff07f
 match = 0x48039057
 
-[format_8-0.instructions.vfcvt_rtz_xu_f_v]
+[format_8-0.instructions."vfcvt.rtz.xu.f.v"]
 mask = 0xfc0ff07f
 match = 0x48031057
 
-[format_8-0.instructions.vfcvt_x_f_v]
+[format_8-0.instructions."vfcvt.x.f.v"]
 mask = 0xfc0ff07f
 match = 0x48009057
 
-[format_8-0.instructions.vfcvt_xu_f_v]
+[format_8-0.instructions."vfcvt.xu.f.v"]
 mask = 0xfc0ff07f
 match = 0x48001057
 
-[format_8-0.instructions.vfncvt_f_f_w]
+[format_8-0.instructions."vfncvt.f.f.w"]
 mask = 0xfc0ff07f
 match = 0x480a1057
 
-[format_8-0.instructions.vfncvt_f_x_w]
+[format_8-0.instructions."vfncvt.f.x.w"]
 mask = 0xfc0ff07f
 match = 0x48099057
 
-[format_8-0.instructions.vfncvt_f_xu_w]
+[format_8-0.instructions."vfncvt.f.xu.w"]
 mask = 0xfc0ff07f
 match = 0x48091057
 
-[format_8-0.instructions.vfncvt_rod_f_f_w]
+[format_8-0.instructions."vfncvt.rod.f.f.w"]
 mask = 0xfc0ff07f
 match = 0x480a9057
 
-[format_8-0.instructions.vfncvt_rtz_x_f_w]
+[format_8-0.instructions."vfncvt.rtz.x.f.w"]
 mask = 0xfc0ff07f
 match = 0x480b9057
 
-[format_8-0.instructions.vfncvt_rtz_xu_f_w]
+[format_8-0.instructions."vfncvt.rtz.xu.f.w"]
 mask = 0xfc0ff07f
 match = 0x480b1057
 
-[format_8-0.instructions.vfncvt_x_f_w]
+[format_8-0.instructions."vfncvt.x.f.w"]
 mask = 0xfc0ff07f
 match = 0x48089057
 
-[format_8-0.instructions.vfncvt_xu_f_w]
+[format_8-0.instructions."vfncvt.xu.f.w"]
 mask = 0xfc0ff07f
 match = 0x48081057
 
-[format_8-0.instructions.vfrec7_v]
+[format_8-0.instructions."vfrec7.v"]
 mask = 0xfc0ff07f
 match = 0x4c029057
 
-[format_8-0.instructions.vfrsqrt7_v]
+[format_8-0.instructions."vfrsqrt7.v"]
 mask = 0xfc0ff07f
 match = 0x4c021057
 
-[format_8-0.instructions.vfsqrt_v]
+[format_8-0.instructions."vfsqrt.v"]
 mask = 0xfc0ff07f
 match = 0x4c001057
 
-[format_8-0.instructions.vfwcvt_f_f_v]
+[format_8-0.instructions."vfwcvt.f.f.v"]
 mask = 0xfc0ff07f
 match = 0x48061057
 
-[format_8-0.instructions.vfwcvt_f_x_v]
+[format_8-0.instructions."vfwcvt.f.x.v"]
 mask = 0xfc0ff07f
 match = 0x48059057
 
-[format_8-0.instructions.vfwcvt_f_xu_v]
+[format_8-0.instructions."vfwcvt.f.xu.v"]
 mask = 0xfc0ff07f
 match = 0x48051057
 
-[format_8-0.instructions.vfwcvt_rtz_x_f_v]
+[format_8-0.instructions."vfwcvt.rtz.x.f.v"]
 mask = 0xfc0ff07f
 match = 0x48079057
 
-[format_8-0.instructions.vfwcvt_rtz_xu_f_v]
+[format_8-0.instructions."vfwcvt.rtz.xu.f.v"]
 mask = 0xfc0ff07f
 match = 0x48071057
 
-[format_8-0.instructions.vfwcvt_x_f_v]
+[format_8-0.instructions."vfwcvt.x.f.v"]
 mask = 0xfc0ff07f
 match = 0x48049057
 
-[format_8-0.instructions.vfwcvt_xu_f_v]
+[format_8-0.instructions."vfwcvt.xu.f.v"]
 mask = 0xfc0ff07f
 match = 0x48041057
 
-[format_8-0.instructions.viota_m]
+[format_8-0.instructions."viota.m"]
 mask = 0xfc0ff07f
 match = 0x50082057
 
-[format_8-0.instructions.vmsbf_m]
+[format_8-0.instructions."vmsbf.m"]
 mask = 0xfc0ff07f
 match = 0x5000a057
 
-[format_8-0.instructions.vmsif_m]
+[format_8-0.instructions."vmsif.m"]
 mask = 0xfc0ff07f
 match = 0x5001a057
 
-[format_8-0.instructions.vmsof_m]
+[format_8-0.instructions."vmsof.m"]
 mask = 0xfc0ff07f
 match = 0x50012057
 
-[format_8-0.instructions.vsext_vf2]
+[format_8-0.instructions."vsext.vf2"]
 mask = 0xfc0ff07f
 match = 0x4803a057
 
-[format_8-0.instructions.vsext_vf4]
+[format_8-0.instructions."vsext.vf4"]
 mask = 0xfc0ff07f
 match = 0x4802a057
 
-[format_8-0.instructions.vsext_vf8]
+[format_8-0.instructions."vsext.vf8"]
 mask = 0xfc0ff07f
 match = 0x4801a057
 
-[format_8-0.instructions.vzext_vf2]
+[format_8-0.instructions."vzext.vf2"]
 mask = 0xfc0ff07f
 match = 0x48032057
 
-[format_8-0.instructions.vzext_vf4]
+[format_8-0.instructions."vzext.vf4"]
 mask = 0xfc0ff07f
 match = 0x48022057
 
-[format_8-0.instructions.vzext_vf8]
+[format_8-0.instructions."vzext.vf8"]
 mask = 0xfc0ff07f
 match = 0x48012057
 
-[format_9-0.instructions.vmv_x_s]
+[format_9-0.instructions."vmv.x.s"]
 mask = 0xfe0ff07f
 match = 0x42002057
 
-[format_9-1.instructions.vfmv_f_s]
+[format_9-1.instructions."vfmv.f.s"]
 mask = 0xfe0ff07f
 match = 0x42001057
 
-[format_10-0.instructions.vl1re16_v]
+[format_10-0.instructions."vl1re16.v"]
 mask = 0xfff0707f
 match = 0x2805007
 
-[format_10-0.instructions.vl1re32_v]
+[format_10-0.instructions."vl1re32.v"]
 mask = 0xfff0707f
 match = 0x2806007
 
-[format_10-0.instructions.vl1re64_v]
+[format_10-0.instructions."vl1re64.v"]
 mask = 0xfff0707f
 match = 0x2807007
 
-[format_10-0.instructions.vl1re8_v]
+[format_10-0.instructions."vl1re8.v"]
 mask = 0xfff0707f
 match = 0x2800007
 
-[format_10-0.instructions.vl2re16_v]
+[format_10-0.instructions."vl2re16.v"]
 mask = 0xfff0707f
 match = 0x22805007
 
-[format_10-0.instructions.vl2re32_v]
+[format_10-0.instructions."vl2re32.v"]
 mask = 0xfff0707f
 match = 0x22806007
 
-[format_10-0.instructions.vl2re64_v]
+[format_10-0.instructions."vl2re64.v"]
 mask = 0xfff0707f
 match = 0x22807007
 
-[format_10-0.instructions.vl2re8_v]
+[format_10-0.instructions."vl2re8.v"]
 mask = 0xfff0707f
 match = 0x22800007
 
-[format_10-0.instructions.vl4re16_v]
+[format_10-0.instructions."vl4re16.v"]
 mask = 0xfff0707f
 match = 0x62805007
 
-[format_10-0.instructions.vl4re32_v]
+[format_10-0.instructions."vl4re32.v"]
 mask = 0xfff0707f
 match = 0x62806007
 
-[format_10-0.instructions.vl4re64_v]
+[format_10-0.instructions."vl4re64.v"]
 mask = 0xfff0707f
 match = 0x62807007
 
-[format_10-0.instructions.vl4re8_v]
+[format_10-0.instructions."vl4re8.v"]
 mask = 0xfff0707f
 match = 0x62800007
 
-[format_10-0.instructions.vl8re16_v]
+[format_10-0.instructions."vl8re16.v"]
 mask = 0xfff0707f
 match = 0xe2805007
 
-[format_10-0.instructions.vl8re32_v]
+[format_10-0.instructions."vl8re32.v"]
 mask = 0xfff0707f
 match = 0xe2806007
 
-[format_10-0.instructions.vl8re64_v]
+[format_10-0.instructions."vl8re64.v"]
 mask = 0xfff0707f
 match = 0xe2807007
 
-[format_10-0.instructions.vl8re8_v]
+[format_10-0.instructions."vl8re8.v"]
 mask = 0xfff0707f
 match = 0xe2800007
 
-[format_10-0.instructions.vlm_v]
+[format_10-0.instructions."vlm.v"]
 mask = 0xfff0707f
 match = 0x2b00007
 
-[format_10-0.instructions.vmv_s_x]
+[format_10-0.instructions."vmv.s.x"]
 mask = 0xfff0707f
 match = 0x42006057
 
-[format_10-0.instructions.vmv_v_x]
+[format_10-0.instructions."vmv.v.x"]
 mask = 0xfff0707f
 match = 0x5e004057
 
-[format_10-1.instructions.vfmv_s_f]
+[format_10-1.instructions."vfmv.s.f"]
 mask = 0xfff0707f
 match = 0x42005057
 
-[format_10-1.instructions.vfmv_v_f]
+[format_10-1.instructions."vfmv.v.f"]
 mask = 0xfff0707f
 match = 0x5e005057
 
-[format_11-0.instructions.vid_v]
+[format_11-0.instructions."vid.v"]
 mask = 0xfdfff07f
 match = 0x5008a057
 
-[format_12-0.instructions.vle16_v]
+[format_12-0.instructions."vle16.v"]
 mask = 0x1df0707f
 match = 0x5007
 
-[format_12-0.instructions.vle16ff_v]
+[format_12-0.instructions."vle16ff.v"]
 mask = 0x1df0707f
 match = 0x1005007
 
-[format_12-0.instructions.vle32_v]
+[format_12-0.instructions."vle32.v"]
 mask = 0x1df0707f
 match = 0x6007
 
-[format_12-0.instructions.vle32ff_v]
+[format_12-0.instructions."vle32ff.v"]
 mask = 0x1df0707f
 match = 0x1006007
 
-[format_12-0.instructions.vle64_v]
+[format_12-0.instructions."vle64.v"]
 mask = 0x1df0707f
 match = 0x7007
 
-[format_12-0.instructions.vle64ff_v]
+[format_12-0.instructions."vle64ff.v"]
 mask = 0x1df0707f
 match = 0x1007007
 
-[format_12-0.instructions.vle8_v]
+[format_12-0.instructions."vle8.v"]
 mask = 0x1df0707f
 match = 0x7
 
-[format_12-0.instructions.vle8ff_v]
+[format_12-0.instructions."vle8ff.v"]
 mask = 0x1df0707f
 match = 0x1000007
 
-[format_13-0.instructions.vloxei16_v]
+[format_13-0.instructions."vloxei16.v"]
 mask = 0x1c00707f
 match = 0xc005007
 
-[format_13-0.instructions.vloxei32_v]
+[format_13-0.instructions."vloxei32.v"]
 mask = 0x1c00707f
 match = 0xc006007
 
-[format_13-0.instructions.vloxei64_v]
+[format_13-0.instructions."vloxei64.v"]
 mask = 0x1c00707f
 match = 0xc007007
 
-[format_13-0.instructions.vloxei8_v]
+[format_13-0.instructions."vloxei8.v"]
 mask = 0x1c00707f
 match = 0xc000007
 
-[format_13-0.instructions.vluxei16_v]
+[format_13-0.instructions."vluxei16.v"]
 mask = 0x1c00707f
 match = 0x4005007
 
-[format_13-0.instructions.vluxei32_v]
+[format_13-0.instructions."vluxei32.v"]
 mask = 0x1c00707f
 match = 0x4006007
 
-[format_13-0.instructions.vluxei64_v]
+[format_13-0.instructions."vluxei64.v"]
 mask = 0x1c00707f
 match = 0x4007007
 
-[format_13-0.instructions.vluxei8_v]
+[format_13-0.instructions."vluxei8.v"]
 mask = 0x1c00707f
 match = 0x4000007
 
-[format_14-0.instructions.vlse16_v]
+[format_14-0.instructions."vlse16.v"]
 mask = 0x1c00707f
 match = 0x8005007
 
-[format_14-0.instructions.vlse32_v]
+[format_14-0.instructions."vlse32.v"]
 mask = 0x1c00707f
 match = 0x8006007
 
-[format_14-0.instructions.vlse64_v]
+[format_14-0.instructions."vlse64.v"]
 mask = 0x1c00707f
 match = 0x8007007
 
-[format_14-0.instructions.vlse8_v]
+[format_14-0.instructions."vlse8.v"]
 mask = 0x1c00707f
 match = 0x8000007
 
-[format_15-0.instructions.vmv1r_v]
+[format_15-0.instructions."vmv1r.v"]
 mask = 0xfe0ff07f
 match = 0x9e003057
 
-[format_15-0.instructions.vmv2r_v]
+[format_15-0.instructions."vmv2r.v"]
 mask = 0xfe0ff07f
 match = 0x9e00b057
 
-[format_15-0.instructions.vmv4r_v]
+[format_15-0.instructions."vmv4r.v"]
 mask = 0xfe0ff07f
 match = 0x9e01b057
 
-[format_15-0.instructions.vmv8r_v]
+[format_15-0.instructions."vmv8r.v"]
 mask = 0xfe0ff07f
 match = 0x9e03b057
 
-[format_16-0.instructions.vmv_v_i]
+[format_16-0.instructions."vmv.v.i"]
 mask = 0xfff0707f
 match = 0x5e003057
 
-[format_17-0.instructions.vmv_v_v]
+[format_17-0.instructions."vmv.v.v"]
 mask = 0xfff0707f
 match = 0x5e000057
 
-[format_18-0.instructions.vs1r_v]
+[format_18-0.instructions."vs1r.v"]
 mask = 0xfff0707f
 match = 0x2800027
 
-[format_18-0.instructions.vs2r_v]
+[format_18-0.instructions."vs2r.v"]
 mask = 0xfff0707f
 match = 0x22800027
 
-[format_18-0.instructions.vs4r_v]
+[format_18-0.instructions."vs4r.v"]
 mask = 0xfff0707f
 match = 0x62800027
 
-[format_18-0.instructions.vs8r_v]
+[format_18-0.instructions."vs8r.v"]
 mask = 0xfff0707f
 match = 0xe2800027
 
-[format_18-0.instructions.vsm_v]
+[format_18-0.instructions."vsm.v"]
 mask = 0xfff0707f
 match = 0x2b00027
 
-[format_19-0.instructions.vse16_v]
+[format_19-0.instructions."vse16.v"]
 mask = 0x1df0707f
 match = 0x5027
 
-[format_19-0.instructions.vse32_v]
+[format_19-0.instructions."vse32.v"]
 mask = 0x1df0707f
 match = 0x6027
 
-[format_19-0.instructions.vse64_v]
+[format_19-0.instructions."vse64.v"]
 mask = 0x1df0707f
 match = 0x7027
 
-[format_19-0.instructions.vse8_v]
+[format_19-0.instructions."vse8.v"]
 mask = 0x1df0707f
 match = 0x27
 
@@ -2968,50 +2968,50 @@ match = 0x80007057
 mask = 0x8000707f
 match = 0x7057
 
-[format_23-0.instructions.vsoxei16_v]
+[format_23-0.instructions."vsoxei16.v"]
 mask = 0x1c00707f
 match = 0xc005027
 
-[format_23-0.instructions.vsoxei32_v]
+[format_23-0.instructions."vsoxei32.v"]
 mask = 0x1c00707f
 match = 0xc006027
 
-[format_23-0.instructions.vsoxei64_v]
+[format_23-0.instructions."vsoxei64.v"]
 mask = 0x1c00707f
 match = 0xc007027
 
-[format_23-0.instructions.vsoxei8_v]
+[format_23-0.instructions."vsoxei8.v"]
 mask = 0x1c00707f
 match = 0xc000027
 
-[format_23-0.instructions.vsuxei16_v]
+[format_23-0.instructions."vsuxei16.v"]
 mask = 0x1c00707f
 match = 0x4005027
 
-[format_23-0.instructions.vsuxei32_v]
+[format_23-0.instructions."vsuxei32.v"]
 mask = 0x1c00707f
 match = 0x4006027
 
-[format_23-0.instructions.vsuxei64_v]
+[format_23-0.instructions."vsuxei64.v"]
 mask = 0x1c00707f
 match = 0x4007027
 
-[format_23-0.instructions.vsuxei8_v]
+[format_23-0.instructions."vsuxei8.v"]
 mask = 0x1c00707f
 match = 0x4000027
 
-[format_24-0.instructions.vsse16_v]
+[format_24-0.instructions."vsse16.v"]
 mask = 0x1c00707f
 match = 0x8005027
 
-[format_24-0.instructions.vsse32_v]
+[format_24-0.instructions."vsse32.v"]
 mask = 0x1c00707f
 match = 0x8006027
 
-[format_24-0.instructions.vsse64_v]
+[format_24-0.instructions."vsse64.v"]
 mask = 0x1c00707f
 match = 0x8007027
 
-[format_24-0.instructions.vsse8_v]
+[format_24-0.instructions."vsse8.v"]
 mask = 0x1c00707f
 match = 0x8000027

--- a/toml/RV_Zawrs.toml
+++ b/toml/RV_Zawrs.toml
@@ -22,10 +22,10 @@ number = 32
 [format-1-0.repr]
 default = "$name$"
 
-[format-1-0.instructions.wrs_nto]
+[format-1-0.instructions."wrs.nto"]
 mask = 0xffffffff
 match = 0xd00073
 
-[format-1-0.instructions.wrs_sto]
+[format-1-0.instructions."wrs.sto"]
 mask = 0xffffffff
 match = 0x1d00073

--- a/toml/RV_Zba.toml
+++ b/toml/RV_Zba.toml
@@ -204,7 +204,7 @@ default = "$name$ %rd_Register_int%, %rs1_Register_int%, %rs2_Register_int%"
 [format_2-0.repr]
 default = "$name$ %rd_Register_int%, %rs1_Register_int%, %shamtd%"
 
-[format_1-0.instructions.add_uw]
+[format_1-0.instructions."add.uw"]
 mask = 0xfe00707f
 match = 0x800003b
 
@@ -212,7 +212,7 @@ match = 0x800003b
 mask = 0xfe00707f
 match = 0x20002033
 
-[format_1-0.instructions.sh1add_uw]
+[format_1-0.instructions."sh1add.uw"]
 mask = 0xfe00707f
 match = 0x2000203b
 
@@ -220,7 +220,7 @@ match = 0x2000203b
 mask = 0xfe00707f
 match = 0x20004033
 
-[format_1-0.instructions.sh2add_uw]
+[format_1-0.instructions."sh2add.uw"]
 mask = 0xfe00707f
 match = 0x2000403b
 
@@ -228,10 +228,10 @@ match = 0x2000403b
 mask = 0xfe00707f
 match = 0x20006033
 
-[format_1-0.instructions.sh3add_uw]
+[format_1-0.instructions."sh3add.uw"]
 mask = 0xfe00707f
 match = 0x2000603b
 
-[format_2-0.instructions.slli_uw]
+[format_2-0.instructions."slli.uw"]
 mask = 0xfc00707f
 match = 0x800101b

--- a/toml/RV_Zcd-lower.toml
+++ b/toml/RV_Zcd-lower.toml
@@ -287,22 +287,22 @@ default = "$name$ %rs2_p_Register_float_c%, %himm%(%rs1_p_Register_int_c%)"
 [format-4-0.repr]
 default = "$name$ %c_rs2_Register_float%, %himm%(sp)"
 
-[format-1-0.instructions.c_fld]
+[format-1-0.instructions."c.fld"]
 mask = 0xe003
 match = 0x2000
 unsigned = true
 
-[format-2-0.instructions.c_fldsp]
+[format-2-0.instructions."c.fldsp"]
 mask = 0xe003
 match = 0x2002
 unsigned = true
 
-[format-3-0.instructions.c_fsd]
+[format-3-0.instructions."c.fsd"]
 mask = 0xe003
 match = 0xa000
 unsigned = true
 
-[format-4-0.instructions.c_fsdsp]
+[format-4-0.instructions."c.fsdsp"]
 mask = 0xe003
 match = 0xa002
 unsigned = true

--- a/toml/RV_Zcd.toml
+++ b/toml/RV_Zcd.toml
@@ -287,22 +287,22 @@ default = "$name$ %rs2_p_Register_float_c%, %himm%(%rs1_p_Register_int_c%)"
 [format-4-0.repr]
 default = "$name$ %c_rs2_Register_float%, %himm%(sp)"
 
-[format-1-0.instructions.c_fld]
+[format-1-0.instructions."c.fld"]
 mask = 0xe003
 match = 0x2000
 unsigned = true
 
-[format-2-0.instructions.c_fldsp]
+[format-2-0.instructions."c.fldsp"]
 mask = 0xe003
 match = 0x2002
 unsigned = true
 
-[format-3-0.instructions.c_fsd]
+[format-3-0.instructions."c.fsd"]
 mask = 0xe003
 match = 0xa000
 unsigned = true
 
-[format-4-0.instructions.c_fsdsp]
+[format-4-0.instructions."c.fsdsp"]
 mask = 0xe003
 match = 0xa002
 unsigned = true

--- a/toml/RV_Zfh.toml
+++ b/toml/RV_Zfh.toml
@@ -537,107 +537,107 @@ default = "$name$ %rd_Register_float%, %rs1_Register_float%, %rs2_Register_float
 [format-7-0.repr]
 default = "$name$ %rs2_Register_float%, %himm%(%rs1_Register_int%)"
 
-[format-1-7.instructions.fadd_h]
+[format-1-7.instructions."fadd.h"]
 mask = 0xfe00007f
 match = 0x4000053
 
-[format-1-7.instructions.fdiv_h]
+[format-1-7.instructions."fdiv.h"]
 mask = 0xfe00007f
 match = 0x1c000053
 
-[format-1-7.instructions.fmul_h]
+[format-1-7.instructions."fmul.h"]
 mask = 0xfe00007f
 match = 0x14000053
 
-[format-1-7.instructions.fsub_h]
+[format-1-7.instructions."fsub.h"]
 mask = 0xfe00007f
 match = 0xc000053
 
-[format-2-1.instructions.fclass_h]
+[format-2-1.instructions."fclass.h"]
 mask = 0xfff0707f
 match = 0xe4001053
 
-[format-2-1.instructions.fmv_x_h]
+[format-2-1.instructions."fmv.x.h"]
 mask = 0xfff0707f
 match = 0xe4000053
 
-[format-2-2.instructions.fmv_h_x]
+[format-2-2.instructions."fmv.h.x"]
 mask = 0xfff0707f
 match = 0xf4000053
 
-[format-3-1.instructions.fcvt_l_h]
+[format-3-1.instructions."fcvt.l.h"]
 mask = 0xfff0007f
 match = 0xc4200053
 
-[format-3-1.instructions.fcvt_lu_h]
+[format-3-1.instructions."fcvt.lu.h"]
 mask = 0xfff0007f
 match = 0xc4300053
 
-[format-3-1.instructions.fcvt_w_h]
+[format-3-1.instructions."fcvt.w.h"]
 mask = 0xfff0007f
 match = 0xc4000053
 
-[format-3-1.instructions.fcvt_wu_h]
+[format-3-1.instructions."fcvt.wu.h"]
 mask = 0xfff0007f
 match = 0xc4100053
 
-[format-3-2.instructions.fcvt_h_l]
+[format-3-2.instructions."fcvt.h.l"]
 mask = 0xfff0007f
 match = 0xd4200053
 
-[format-3-2.instructions.fcvt_h_lu]
+[format-3-2.instructions."fcvt.h.lu"]
 mask = 0xfff0007f
 match = 0xd4300053
 
-[format-3-2.instructions.fcvt_h_w]
+[format-3-2.instructions."fcvt.h.w"]
 mask = 0xfff0007f
 match = 0xd4000053
 
-[format-3-2.instructions.fcvt_h_wu]
+[format-3-2.instructions."fcvt.h.wu"]
 mask = 0xfff0007f
 match = 0xd4100053
 
-[format-3-3.instructions.fcvt_h_s]
+[format-3-3.instructions."fcvt.h.s"]
 mask = 0xfff0007f
 match = 0x44000053
 
-[format-3-3.instructions.fcvt_s_h]
+[format-3-3.instructions."fcvt.s.h"]
 mask = 0xfff0007f
 match = 0x40200053
 
-[format-3-3.instructions.fsqrt_h]
+[format-3-3.instructions."fsqrt.h"]
 mask = 0xfff0007f
 match = 0x5c000053
 
-[format-4-3.instructions.feq_h]
+[format-4-3.instructions."feq.h"]
 mask = 0xfe00707f
 match = 0xa4002053
 
-[format-4-3.instructions.fle_h]
+[format-4-3.instructions."fle.h"]
 mask = 0xfe00707f
 match = 0xa4000053
 
-[format-4-3.instructions.flt_h]
+[format-4-3.instructions."flt.h"]
 mask = 0xfe00707f
 match = 0xa4001053
 
-[format-4-7.instructions.fmax_h]
+[format-4-7.instructions."fmax.h"]
 mask = 0xfe00707f
 match = 0x2c001053
 
-[format-4-7.instructions.fmin_h]
+[format-4-7.instructions."fmin.h"]
 mask = 0xfe00707f
 match = 0x2c000053
 
-[format-4-7.instructions.fsgnj_h]
+[format-4-7.instructions."fsgnj.h"]
 mask = 0xfe00707f
 match = 0x24000053
 
-[format-4-7.instructions.fsgnjn_h]
+[format-4-7.instructions."fsgnjn.h"]
 mask = 0xfe00707f
 match = 0x24001053
 
-[format-4-7.instructions.fsgnjx_h]
+[format-4-7.instructions."fsgnjx.h"]
 mask = 0xfe00707f
 match = 0x24002053
 
@@ -645,19 +645,19 @@ match = 0x24002053
 mask = 0x707f
 match = 0x1007
 
-[format-6-15.instructions.fmadd_h]
+[format-6-15.instructions."fmadd.h"]
 mask = 0x600007f
 match = 0x4000043
 
-[format-6-15.instructions.fmsub_h]
+[format-6-15.instructions."fmsub.h"]
 mask = 0x600007f
 match = 0x4000047
 
-[format-6-15.instructions.fnmadd_h]
+[format-6-15.instructions."fnmadd.h"]
 mask = 0x600007f
 match = 0x400004f
 
-[format-6-15.instructions.fnmsub_h]
+[format-6-15.instructions."fnmsub.h"]
 mask = 0x600007f
 match = 0x400004b
 

--- a/toml/RV_Zicbo.toml
+++ b/toml/RV_Zicbo.toml
@@ -153,30 +153,30 @@ default = "$name$ %rs1_Register_int%"
 [format-2-0.repr]
 default = "$name$ %himm%(%rs1_Register_int%)"
 
-[format-1-0.instructions.cbo_clean]
+[format-1-0.instructions."cbo.clean"]
 mask = 0xfff07fff
 match = 0x10200f
 
-[format-1-0.instructions.cbo_flush]
+[format-1-0.instructions."cbo.flush"]
 mask = 0xfff07fff
 match = 0x20200f
 
-[format-1-0.instructions.cbo_inval]
+[format-1-0.instructions."cbo.inval"]
 mask = 0xfff07fff
 match = 0x200f
 
-[format-1-0.instructions.cbo_zero]
+[format-1-0.instructions."cbo.zero"]
 mask = 0xfff07fff
 match = 0x40200f
 
-[format-2-0.instructions.prefetch_i]
+[format-2-0.instructions."prefetch.i"]
 mask = 0x1f07fff
 match = 0x6013
 
-[format-2-0.instructions.prefetch_r]
+[format-2-0.instructions."prefetch.r"]
 mask = 0x1f07fff
 match = 0x106013
 
-[format-2-0.instructions.prefetch_w]
+[format-2-0.instructions."prefetch.w"]
 mask = 0x1f07fff
 match = 0x306013

--- a/toml/RV_Zicond.toml
+++ b/toml/RV_Zicond.toml
@@ -162,10 +162,10 @@ Register_float = [
 [format-1-0.repr]
 default = "$name$ %rd_Register_int%, %rs1_Register_int%, %rs2_Register_int%"
 
-[format-1-0.instructions.czero_eqz]
+[format-1-0.instructions."czero.eqz"]
 mask = 0xfe00707f
 match = 0xe005033
 
-[format-1-0.instructions.czero_nez]
+[format-1-0.instructions."czero.nez"]
 mask = 0xfe00707f
 match = 0xe007033

--- a/toml/RV_Zifencei.toml
+++ b/toml/RV_Zifencei.toml
@@ -147,6 +147,6 @@ Register_float = [
 [format-1-0.repr]
 default = "$name$"
 
-[format-1-0.instructions.fence_i]
+[format-1-0.instructions."fence.i"]
 mask = 0x707f
 match = 0x100f

--- a/toml/RV_Zihintntl.toml
+++ b/toml/RV_Zihintntl.toml
@@ -22,18 +22,18 @@ number = 32
 [format-1-0.repr]
 default = "$name$"
 
-[format-1-0.instructions.ntl_all]
+[format-1-0.instructions."ntl.all"]
 mask = 0xffffffff
 match = 0x500033
 
-[format-1-0.instructions.ntl_p1]
+[format-1-0.instructions."ntl.p1"]
 mask = 0xffffffff
 match = 0x200033
 
-[format-1-0.instructions.ntl_pall]
+[format-1-0.instructions."ntl.pall"]
 mask = 0xffffffff
 match = 0x300033
 
-[format-1-0.instructions.ntl_s1]
+[format-1-0.instructions."ntl.s1"]
 mask = 0xffffffff
 match = 0x400033

--- a/toml/RV_Zimop.toml
+++ b/toml/RV_Zimop.toml
@@ -239,12 +239,12 @@ default = "$name$.%imm% %rd_Register_int%, %rs1_Register_int%"
 [format-4-0.repr]
 default = "$name$.%imm% %rd_Register_int%, %rs1_Register_int%, %rs2_Register_int%"
 
-[format-2-0.instructions.mop_r]
+[format-2-0.instructions."mop.r"]
 mask = 0xb3c0707f
 match = 0x81c04073
 unsigned = true
 
-[format-4-0.instructions.mop_rr]
+[format-4-0.instructions."mop.rr"]
 mask = 0xb200707f
 match = 0x82004073
 unsigned = true

--- a/toml/RV_Zvbb.toml
+++ b/toml/RV_Zvbb.toml
@@ -366,68 +366,68 @@ default = "$name$ %vd%, %vs2%, %himm%%vm%"
 [format-5-0.repr]
 default = "$name$ %vd%, %vs2%, %himm%%vm%"
 
-[format-1-0.instructions.vandn_vv]
+[format-1-0.instructions."vandn.vv"]
 mask = 0xfc00707f
 match = 0x4000057
 
-[format-1-0.instructions.vrol_vv]
+[format-1-0.instructions."vrol.vv"]
 mask = 0xfc00707f
 match = 0x54000057
 
-[format-1-0.instructions.vror_vv]
+[format-1-0.instructions."vror.vv"]
 mask = 0xfc00707f
 match = 0x50000057
 
-[format-1-0.instructions.vwsll_vv]
+[format-1-0.instructions."vwsll.vv"]
 mask = 0xfc00707f
 match = 0xd4000057
 
-[format-2-0.instructions.vandn_vx]
+[format-2-0.instructions."vandn.vx"]
 mask = 0xfc00707f
 match = 0x4004057
 
-[format-2-0.instructions.vrol_vx]
+[format-2-0.instructions."vrol.vx"]
 mask = 0xfc00707f
 match = 0x54004057
 
-[format-2-0.instructions.vror_vx]
+[format-2-0.instructions."vror.vx"]
 mask = 0xfc00707f
 match = 0x50004057
 
-[format-2-0.instructions.vwsll_vx]
+[format-2-0.instructions."vwsll.vx"]
 mask = 0xfc00707f
 match = 0xd4004057
 
-[format-3-0.instructions.vbrev8_v]
+[format-3-0.instructions."vbrev8.v"]
 mask = 0xfc0ff07f
 match = 0x48042057
 
-[format-3-0.instructions.vbrev_v]
+[format-3-0.instructions."vbrev.v"]
 mask = 0xfc0ff07f
 match = 0x48052057
 
-[format-3-0.instructions.vclz_v]
+[format-3-0.instructions."vclz.v"]
 mask = 0xfc0ff07f
 match = 0x48062057
 
-[format-3-0.instructions.vcpop_v]
+[format-3-0.instructions."vcpop.v"]
 mask = 0xfc0ff07f
 match = 0x48072057
 
-[format-3-0.instructions.vctz_v]
+[format-3-0.instructions."vctz.v"]
 mask = 0xfc0ff07f
 match = 0x4806a057
 
-[format-3-0.instructions.vrev8_v]
+[format-3-0.instructions."vrev8.v"]
 mask = 0xfc0ff07f
 match = 0x4804a057
 
-[format-4-0.instructions.vror_vi]
+[format-4-0.instructions."vror.vi"]
 mask = 0xf800707f
 match = 0x50003057
 unsigned = true
 
-[format-5-0.instructions.vwsll_vi]
+[format-5-0.instructions."vwsll.vi"]
 mask = 0xfc00707f
 match = 0xd4003057
 unsigned = true

--- a/toml/RV_Zvbc.toml
+++ b/toml/RV_Zvbc.toml
@@ -243,18 +243,18 @@ default = "$name$ %vd%, %vs2%, %vs1%%vm%"
 [format-2-0.repr]
 default = "$name$ %vd%, %vs2%, %rs1_Register_int%%vm%"
 
-[format-1-0.instructions.vclmul_vv]
+[format-1-0.instructions."vclmul.vv"]
 mask = 0xfc00707f
 match = 0x30002057
 
-[format-1-0.instructions.vclmulh_vv]
+[format-1-0.instructions."vclmulh.vv"]
 mask = 0xfc00707f
 match = 0x34002057
 
-[format-2-0.instructions.vclmul_vx]
+[format-2-0.instructions."vclmul.vx"]
 mask = 0xfc00707f
 match = 0x30006057
 
-[format-2-0.instructions.vclmulh_vx]
+[format-2-0.instructions."vclmulh.vx"]
 mask = 0xfc00707f
 match = 0x34006057

--- a/toml/RV_Zvkg.toml
+++ b/toml/RV_Zvkg.toml
@@ -144,10 +144,10 @@ default = "$name$ %vd%, %vs2%, %vs1%"
 [format-2-0.repr]
 default = "$name$ %vd%, %vs2%"
 
-[format-1-0.instructions.vghsh_vv]
+[format-1-0.instructions."vghsh.vv"]
 mask = 0xfe00707f
 match = 0xb2002077
 
-[format-2-0.instructions.vgmul_vv]
+[format-2-0.instructions."vgmul.vv"]
 mask = 0xfe0ff07f
 match = 0xa208a077

--- a/toml/RV_Zvkned.toml
+++ b/toml/RV_Zvkned.toml
@@ -139,48 +139,48 @@ default = "$name$ %vd%, %vs2%"
 [format_2-0.repr]
 default = "$name$ %vd%, %vs2%, %himm%"
 
-[format_1-0.instructions.vaesdf_vs]
+[format_1-0.instructions."vaesdf.vs"]
 mask = 0xfe0ff07f
 match = 0xa600a077
 
-[format_1-0.instructions.vaesdf_vv]
+[format_1-0.instructions."vaesdf.vv"]
 mask = 0xfe0ff07f
 match = 0xa200a077
 
-[format_1-0.instructions.vaesdm_vs]
+[format_1-0.instructions."vaesdm.vs"]
 mask = 0xfe0ff07f
 match = 0xa6002077
 
-[format_1-0.instructions.vaesdm_vv]
+[format_1-0.instructions."vaesdm.vv"]
 mask = 0xfe0ff07f
 match = 0xa2002077
 
-[format_1-0.instructions.vaesef_vs]
+[format_1-0.instructions."vaesef.vs"]
 mask = 0xfe0ff07f
 match = 0xa601a077
 
-[format_1-0.instructions.vaesef_vv]
+[format_1-0.instructions."vaesef.vv"]
 mask = 0xfe0ff07f
 match = 0xa201a077
 
-[format_1-0.instructions.vaesem_vs]
+[format_1-0.instructions."vaesem.vs"]
 mask = 0xfe0ff07f
 match = 0xa6012077
 
-[format_1-0.instructions.vaesem_vv]
+[format_1-0.instructions."vaesem.vv"]
 mask = 0xfe0ff07f
 match = 0xa2012077
 
-[format_1-0.instructions.vaesz_vs]
+[format_1-0.instructions."vaesz.vs"]
 mask = 0xfe0ff07f
 match = 0xa603a077
 
-[format_2-0.instructions.vaeskf1_vi]
+[format_2-0.instructions."vaeskf1.vi"]
 mask = 0xfe00707f
 match = 0x8a002077
 unsigned = true
 
-[format_2-0.instructions.vaeskf2_vi]
+[format_2-0.instructions."vaeskf2.vi"]
 mask = 0xfe00707f
 match = 0xaa002077
 unsigned = true

--- a/toml/RV_Zvknha.toml
+++ b/toml/RV_Zvknha.toml
@@ -113,14 +113,14 @@ Register_vec = [
 [format-1-0.repr]
 default = "$name$ %vd%, %vs2%, %vs1%"
 
-[format-1-0.instructions.vsha2ch_vv]
+[format-1-0.instructions."vsha2ch.vv"]
 mask = 0xfe00707f
 match = 0xba002077
 
-[format-1-0.instructions.vsha2cl_vv]
+[format-1-0.instructions."vsha2cl.vv"]
 mask = 0xfe00707f
 match = 0xbe002077
 
-[format-1-0.instructions.vsha2ms_vv]
+[format-1-0.instructions."vsha2ms.vv"]
 mask = 0xfe00707f
 match = 0xb6002077

--- a/toml/RV_Zvknhb.toml
+++ b/toml/RV_Zvknhb.toml
@@ -113,14 +113,14 @@ Register_vec = [
 [format-1-0.repr]
 default = "$name$ %vd%, %vs2%, %vs1%"
 
-[format-1-0.instructions.vsha2ch_vv]
+[format-1-0.instructions."vsha2ch.vv"]
 mask = 0xfe00707f
 match = 0xba002077
 
-[format-1-0.instructions.vsha2cl_vv]
+[format-1-0.instructions."vsha2cl.vv"]
 mask = 0xfe00707f
 match = 0xbe002077
 
-[format-1-0.instructions.vsha2ms_vv]
+[format-1-0.instructions."vsha2ms.vv"]
 mask = 0xfe00707f
 match = 0xb6002077

--- a/toml/RV_Zvksed.toml
+++ b/toml/RV_Zvksed.toml
@@ -139,15 +139,15 @@ default = "$name$ %vd%, %vs2%, %himm%"
 [format-2-0.repr]
 default = "$name$ %vd%, %vs2%"
 
-[format-1-0.instructions.vsm4k_vi]
+[format-1-0.instructions."vsm4k.vi"]
 mask = 0xfe00707f
 match = 0x86002077
 unsigned = true
 
-[format-2-0.instructions.vsm4r_vs]
+[format-2-0.instructions."vsm4r.vs"]
 mask = 0xfe0ff07f
 match = 0xa6082077
 
-[format-2-0.instructions.vsm4r_vv]
+[format-2-0.instructions."vsm4r.vv"]
 mask = 0xfe0ff07f
 match = 0xa2082077

--- a/toml/RV_Zvksh.toml
+++ b/toml/RV_Zvksh.toml
@@ -149,11 +149,11 @@ default = "$name$ %vd%, %vs2%, %himm%"
 [format-2-0.repr]
 default = "$name$ %vd%, %vs2%, %vs1%"
 
-[format-1-0.instructions.vsm3c_vi]
+[format-1-0.instructions."vsm3c.vi"]
 mask = 0xfe00707f
 match = 0xae002077
 unsigned = true
 
-[format-2-0.instructions.vsm3me_vv]
+[format-2-0.instructions."vsm3me.vv"]
 mask = 0xfe00707f
 match = 0x82002077

--- a/tomlspec.md
+++ b/tomlspec.md
@@ -35,5 +35,5 @@ required entries:
       - [`unsigned`] type `boolean`, True if all `VInt` parts in the type should be decoded as unsigned. If the entry is missing, it implies False, and thus all `VInt` will be signed
   - `repr` type `map` 
     - `default` for representing the default formatting
-      - the format string works in the way, that it replaces certain parts of the string, i.e. `%<name_of_part>%` with the corresponding decoded value of the part in the type, as well as `$name$` with the name of the instruction, with all occurrences of `_` replaced with `.` in the name
+      - the format string works in the way, that it replaces certain parts of the string, i.e. `%<name_of_part>%` with the corresponding decoded value of the part in the type, as well as `$name$` with the name of the instruction
     - `<name-of-instruction>` for overriding the formatting for single instructions


### PR DESCRIPTION
Literal dots can be represented and parsed correctly with TOML's quoted keys[^1].

Closes #31.

[^1]: <https://toml.io/en/v1.0.0#keys>