### PR TITLE
Add RV32I mret/sret/dret/wfi

### DIFF
--- a/toml/RV32I.toml
+++ b/toml/RV32I.toml
@@ -614,6 +614,22 @@ match = 0x100073
 mask = 0xffffffff
 match = 0x73
 
+[format_5-0.instructions.mret]
+mask = 0xffffffff
+match = 0x30200073
+
+[format_5-0.instructions.sret]
+mask = 0xffffffff
+match = 0x10200073
+
+[format_5-0.instructions.dret]
+mask = 0xffffffff
+match = 0x7b200073
+
+[format_5-0.instructions.wfi]
+mask = 0xffffffff
+match = 0x10500073
+
 [format_6-0.instructions.fence]
 mask = 0x707f
 match = 0xf


### PR DESCRIPTION
Within surfer I've been using the rv32 decoder, which uses this as the underlying decoder. 

With this change mret/sret/dret and wifi opcodes are correctly decoded.